### PR TITLE
refactor: rename category terminology to theme throughout codebase

### DIFF
--- a/apps/web/app/recommendations/page.tsx
+++ b/apps/web/app/recommendations/page.tsx
@@ -10,13 +10,13 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { CardSpendingSummary } from '@/components/CardSpendingSummary';
 import { RealTimeRecommendations, type CardOption } from '@/lib/real-time-recommendations';
-import { useCategoryGroups, useCreditCards, useSettings, useYnabPAT, useSelectedBudget } from '@/hooks/useLocalStorage';
+import { useThemeGroups, useCreditCards, useSettings, useYnabPAT, useSelectedBudget } from '@/hooks/useLocalStorage';
 import type { Transaction } from '@/types/transaction';
 
 
 export default function RecommendationsPage() {
   const { cards } = useCreditCards();
-  const { categoryGroups } = useCategoryGroups();
+  const { themeGroups } = useThemeGroups();
   const { settings } = useSettings();
   const { pat } = useYnabPAT();
   const { selectedBudget } = useSelectedBudget();
@@ -29,8 +29,8 @@ export default function RecommendationsPage() {
 
   const recommendations = useMemo(() => {
     const engine = new RealTimeRecommendations(settings);
-    return engine.generateRecommendations(categoryGroups, cards, transactions);
-  }, [categoryGroups, cards, transactions, settings]);
+    return engine.generateRecommendations(themeGroups, cards, transactions);
+  }, [themeGroups, cards, transactions, settings]);
 
   const formatPercent = useCallback((value?: number | null) => {
     if (value == null || Number.isNaN(value)) {
@@ -168,7 +168,7 @@ export default function RecommendationsPage() {
     );
   };
 
-  if (categoryGroups.length === 0) {
+  if (themeGroups.length === 0) {
     return (
       <div className="container mx-auto max-w-6xl px-4 py-8">
         <Card>

--- a/apps/web/app/rules/page.tsx
+++ b/apps/web/app/rules/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useCallback, Suspense } from 'react';
-import { useCategoryGroups, useCreditCards, useSettings } from '@/hooks/useLocalStorage';
+import { useThemeGroups, useCreditCards, useSettings } from '@/hooks/useLocalStorage';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -18,7 +18,7 @@ import {
 } from 'lucide-react';
 import { storage, type CardSubcategory, type CreditCard } from '@/lib/storage';
 import { CardSettingsEditor, type CardEditState as SingleCardEditState } from '@/components/CardSettingsEditor';
-import { CategoryGroupingManager } from '@/components/CategoryGroupingManager';
+import { ThemeGroupingManager } from '@/components/ThemeGroupingManager';
 import { prepareSubcategoriesForSave } from '@/lib/subcategory-utils';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -28,7 +28,7 @@ interface CardEditState {
 
 function RulesPageContent() {
   const { cards, updateCard } = useCreditCards();
-  const { categoryGroups, saveCategoryGroup, deleteCategoryGroup } = useCategoryGroups();
+  const { themeGroups, saveThemeGroup, deleteThemeGroup } = useThemeGroups();
   const { settings } = useSettings();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -348,7 +348,7 @@ function RulesPageContent() {
           </TabsTrigger>
           <TabsTrigger value="themes" className="gap-2">
             <Layers className="h-4 w-4" />
-            Themes ({categoryGroups.length})
+            Themes ({themeGroups.length})
           </TabsTrigger>
         </TabsList>
 
@@ -455,11 +455,11 @@ function RulesPageContent() {
         </TabsContent>
 
         <TabsContent value="themes" className="space-y-4">
-          <CategoryGroupingManager
+          <ThemeGroupingManager
             cards={cards}
-            categoryGroups={categoryGroups}
-            onSaveGroup={saveCategoryGroup}
-            onDeleteGroup={deleteCategoryGroup}
+            themeGroups={themeGroups}
+            onSaveGroup={saveThemeGroup}
+            onDeleteGroup={deleteThemeGroup}
           />
         </TabsContent>
       </Tabs>

--- a/apps/web/components/ThemeGroupingManager.tsx
+++ b/apps/web/components/ThemeGroupingManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import type { CardSubcategory, CreditCard, SpendingCategoryGroup } from '@/lib/storage';
+import type { CardSubcategory, CreditCard, ThemeGroup } from '@/lib/storage';
 import {
   Card,
   CardContent,
@@ -32,10 +32,10 @@ import {
   CreditCard as CreditCardIcon,
 } from 'lucide-react';
 
-interface CategoryGroupingManagerProps {
+interface ThemeGroupingManagerProps {
   cards: CreditCard[];
-  categoryGroups: SpendingCategoryGroup[];
-  onSaveGroup: (group: SpendingCategoryGroup) => void;
+  themeGroups: ThemeGroup[];
+  onSaveGroup: (group: ThemeGroup) => void;
   onDeleteGroup: (groupId: string) => void;
 }
 
@@ -55,16 +55,16 @@ function normaliseText(value: string) {
   return value.toLocaleLowerCase();
 }
 
-export function CategoryGroupingManager({
+export function ThemeGroupingManager({
   cards,
-  categoryGroups,
+  themeGroups,
   onSaveGroup,
   onDeleteGroup,
-}: CategoryGroupingManagerProps) {
+}: ThemeGroupingManagerProps) {
   const [groupFormState, setGroupFormState] = useState<
     | {
         mode: 'create' | 'edit';
-        group: SpendingCategoryGroup | null;
+        group: ThemeGroup | null;
         name: string;
         description: string;
       }
@@ -72,14 +72,14 @@ export function CategoryGroupingManager({
   >(null);
   const [assignmentState, setAssignmentState] = useState<
     | {
-        group: SpendingCategoryGroup;
+        group: ThemeGroup;
         selectedSubcategories: Set<string>;
         selectedCards: Set<string>;
         search: string;
       }
     | null
   >(null);
-  const [groupPendingDeletion, setGroupPendingDeletion] = useState<SpendingCategoryGroup | null>(null);
+  const [groupPendingDeletion, setGroupPendingDeletion] = useState<ThemeGroup | null>(null);
 
   const subcategoryOptions = useMemo<SubcategoryOption[]>(() => {
     const entries: SubcategoryOption[] = [];
@@ -124,8 +124,8 @@ export function CategoryGroupingManager({
   [cards]);
 
   const subcategoryAssignments = useMemo(() => {
-    const map = new Map<string, SpendingCategoryGroup[]>();
-    categoryGroups.forEach((group) => {
+    const map = new Map<string, ThemeGroup[]>();
+    themeGroups.forEach((group) => {
       group.subcategories.forEach((ref) => {
         // Defensive check for runtime safety, though types should ensure these exist
         if (ref?.cardId && ref?.subcategoryId) {
@@ -140,11 +140,11 @@ export function CategoryGroupingManager({
       });
     });
     return map;
-  }, [categoryGroups]);
+  }, [themeGroups]);
 
   const assignedCardLookup = useMemo(() => {
-    const map = new Map<string, SpendingCategoryGroup>();
-    categoryGroups.forEach((group) => {
+    const map = new Map<string, ThemeGroup>();
+    themeGroups.forEach((group) => {
       (group.cards ?? []).forEach((ref) => {
         if (ref?.cardId) {
           map.set(ref.cardId, group);
@@ -152,13 +152,13 @@ export function CategoryGroupingManager({
       });
     });
     return map;
-  }, [categoryGroups]);
+  }, [themeGroups]);
 
   const openCreateDialog = () => {
     setGroupFormState({ mode: 'create', group: null, name: '', description: '' });
   };
 
-  const openEditDialog = (group: SpendingCategoryGroup) => {
+  const openEditDialog = (group: ThemeGroup) => {
     setGroupFormState({
       mode: 'edit',
       group,
@@ -186,7 +186,7 @@ export function CategoryGroupingManager({
         name,
         description: description || undefined,
         colour: undefined,
-        priority: categoryGroups.length,
+        priority: themeGroups.length,
         subcategories: [],
         cards: [],
         createdAt: nowIso,
@@ -205,7 +205,7 @@ export function CategoryGroupingManager({
     setGroupFormState(null);
   };
 
-  const openAssignmentDialog = (group: SpendingCategoryGroup) => {
+  const openAssignmentDialog = (group: ThemeGroup) => {
     const selectedSubcategories = new Set<string>();
     group.subcategories.forEach((ref) => {
       selectedSubcategories.add(buildKey(ref.cardId, ref.subcategoryId));
@@ -328,13 +328,13 @@ export function CategoryGroupingManager({
         </div>
       </div>
 
-      {categoryGroups.length === 0 ? (
+      {themeGroups.length === 0 ? (
         <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
           No themes yet. Click <span className="font-medium">Create theme</span> to start grouping subcategories or link entire cards.
         </div>
       ) : (
         <div className="space-y-4">
-          {categoryGroups.map((group) => {
+          {themeGroups.map((group) => {
             const assignedSubcategoryKeys = group.subcategories.map((ref) =>
               buildKey(ref.cardId, ref.subcategoryId)
             );

--- a/apps/web/hooks/useLocalStorage.ts
+++ b/apps/web/hooks/useLocalStorage.ts
@@ -4,7 +4,7 @@ import type {
   RewardRule,
   RewardCalculation,
   AppSettings,
-  SpendingCategoryGroup,
+  ThemeGroup,
 } from '@/lib/storage';
 import { storage } from '@/lib/storage';
 import { useStorageContext } from '@/contexts/StorageContext';
@@ -14,7 +14,7 @@ const EMPTY_CARD_LIST: CreditCard[] = [];
 const EMPTY_RULE_LIST: RewardRule[] = [];
 const EMPTY_CALCULATION_LIST: RewardCalculation[] = [];
 const EMPTY_SELECTED_BUDGET: { id?: string; name?: string } = {};
-const EMPTY_CATEGORY_GROUP_LIST: SpendingCategoryGroup[] = [];
+const EMPTY_THEME_GROUP_LIST: ThemeGroup[] = [];
 const DEFAULT_SETTINGS: AppSettings = { theme: 'light', currency: 'USD' };
 
 function useHasHydrated() {
@@ -187,32 +187,32 @@ export function useRewardCalculations(cardId?: string) {
   return { calculations, saveCalculation, deleteCalculation, clearCalculations, isLoading: !hasHydrated };
 }
 
-export function useCategoryGroups() {
+export function useThemeGroups() {
   const { refreshTrigger, triggerRefresh } = useStorageContext();
   const hasHydrated = useHasHydrated();
 
-  const categoryGroups = useMemo(() => {
+  const themeGroups = useMemo(() => {
     if (!hasHydrated || typeof window === 'undefined') {
-      return EMPTY_CATEGORY_GROUP_LIST;
+      return EMPTY_THEME_GROUP_LIST;
     }
-    return storage.getCategoryGroups();
+    return storage.getThemeGroups();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasHydrated, refreshTrigger]);
 
-  const saveCategoryGroup = useCallback((group: SpendingCategoryGroup) => {
-    storage.saveCategoryGroup(group);
+  const saveThemeGroup = useCallback((group: ThemeGroup) => {
+    storage.saveThemeGroup(group);
     triggerRefresh();
   }, [triggerRefresh]);
 
-  const deleteCategoryGroup = useCallback((groupId: string) => {
-    storage.deleteCategoryGroup(groupId);
+  const deleteThemeGroup = useCallback((groupId: string) => {
+    storage.deleteThemeGroup(groupId);
     triggerRefresh();
   }, [triggerRefresh]);
 
   return {
-    categoryGroups,
-    saveCategoryGroup,
-    deleteCategoryGroup,
+    themeGroups,
+    saveThemeGroup,
+    deleteThemeGroup,
     isLoading: !hasHydrated,
   };
 }

--- a/apps/web/lib/real-time-recommendations.ts
+++ b/apps/web/lib/real-time-recommendations.ts
@@ -6,7 +6,7 @@
 import type {
   CreditCard,
   CardSubcategory,
-  SpendingCategoryGroup,
+  ThemeGroup,
   AppSettings,
 } from '@/lib/storage';
 import type { Transaction } from '@/types/transaction';
@@ -66,7 +66,7 @@ export class RealTimeRecommendations {
    * Generate recommendations for all themes
    */
   generateRecommendations(
-    themes: SpendingCategoryGroup[],
+    themes: ThemeGroup[],
     cards: CreditCard[],
     transactions: Transaction[]
   ): ThemeRecommendation[] {
@@ -185,7 +185,7 @@ export class RealTimeRecommendations {
    * Generate recommendation for a specific theme
    */
   private recommendForTheme(
-    theme: SpendingCategoryGroup,
+    theme: ThemeGroup,
     cards: CreditCard[],
     spendingSummaries: Map<string, CardSpendingSummary>
   ): ThemeRecommendation {
@@ -259,7 +259,7 @@ export class RealTimeRecommendations {
    */
   private evaluateCard(
     card: CreditCard,
-    theme: SpendingCategoryGroup,
+    theme: ThemeGroup,
     spending?: CardSpendingSummary
   ): CardOption | null {
     const currentSpend = spending?.totalSpend || 0;

--- a/apps/web/lib/rewards-engine/recommendations.ts
+++ b/apps/web/lib/rewards-engine/recommendations.ts
@@ -6,7 +6,7 @@ import type {
   RewardCalculation,
   CreditCard,
   AppSettings,
-  SpendingCategoryGroup,
+  ThemeGroup,
   SubcategoryBreakdown,
   CardSubcategory,
   SubcategoryReference,
@@ -138,7 +138,7 @@ export class RecommendationEngine {
   static generateCategoryRecommendations(
     cards: CreditCard[],
     calculations: RewardCalculation[],
-    groups: SpendingCategoryGroup[],
+    groups: ThemeGroup[],
     settings?: AppSettings
   ): CategoryRecommendation[] {
     if (!groups || groups.length === 0) {

--- a/apps/web/lib/storage.ts
+++ b/apps/web/lib/storage.ts
@@ -357,7 +357,7 @@ class StorageService {
   ): ThemeGroup {
     const nowIso = new Date().toISOString();
     const id = typeof group.id === 'string' && group.id.length > 0 ? group.id : this.createGroupId();
-    const name = typeof group.name === 'string' && group.name.trim().length > 0 ? group.name.trim() : 'Untitled theme';
+    const name = typeof group.name === 'string' && group.name.trim().length > 0 ? group.name.trim() : 'Untitled Theme';
     const description = typeof group.description === 'string' && group.description.trim().length > 0
       ? group.description.trim()
       : undefined;
@@ -639,7 +639,8 @@ class StorageService {
           const legacyGroups = (data as { categoryGroups?: unknown }).categoryGroups;
           data.themeGroups = Array.isArray(legacyGroups) ? (legacyGroups as ThemeGroup[]) : [];
           if (legacyGroups) {
-            Reflect.deleteProperty(data as Record<string, unknown>, 'categoryGroups');
+            // Safe deletion using type assertion through unknown
+            Reflect.deleteProperty(data as unknown as Record<string, unknown>, 'categoryGroups');
           }
         }
         this.pruneThemeGroups(data);


### PR DESCRIPTION
## Summary
- Comprehensive refactoring to rename all "category" references to "theme" for better clarity
- Includes automatic migration for existing data
- Builds on top of PR #27 (UI refinements)

## Changes
- **Type Definitions**: Renamed `SpendingCategoryGroup` → `ThemeGroup`
- **Storage Layer**: Updated from `categoryGroups` → `themeGroups` with backwards compatibility
- **Hooks**: Changed `useCategoryGroups` → `useThemeGroups`
- **Components**: Renamed `CategoryGroupingManager` → `ThemeGroupingManager`
- **Recommendations**: Updated all references in recommendations engine
- **Data Migration**: Added automatic migration from legacy `categoryGroups` to `themeGroups`

## Breaking Changes
Storage key changed from `categoryGroups` to `themeGroups`. Automatic migration is included for existing data, so users won't lose their configuration.

## Test Plan
- [ ] Verify existing category groups migrate to theme groups on first load
- [ ] Test creating, editing, and deleting theme groups
- [ ] Verify recommendations work with the new terminology
- [ ] Check that all UI references show "themes" instead of "categories"
- [ ] Ensure no console errors during migration

🤖 Generated with [Claude Code](https://claude.ai/code)