### PR TITLE
fix: handle billing cycles on 31st and fix timezone issues

### DIFF
--- a/apps/web/lib/rewards-engine/compute.ts
+++ b/apps/web/lib/rewards-engine/compute.ts
@@ -8,16 +8,13 @@ import { YnabClient } from '@/lib/ynab-client';
 import { RewardsCalculator } from './calculator';
 import { SimpleRewardsCalculator } from './simple-calculator';
 import { TransactionMatcher } from './matcher';
+import { formatLocalDate } from './date-utils';
 import type {
   AppSettings,
   CreditCard,
   RewardCalculation,
   RewardRule,
 } from '@/lib/storage';
-
-function formatIsoDate(d: Date): string {
-  return d.toISOString().split('T')[0];
-}
 
 function periodOverlapsWindow(periodStart: Date, periodEnd: Date, start?: string, end?: string): boolean {
   const windowStart = start ? new Date(start) : undefined;
@@ -45,7 +42,7 @@ export async function computeCurrentPeriod(
   // Optimisation: single fetch for all transactions since the earliest period start
   const periods = trackedCards.map(c => RewardsCalculator.calculatePeriod(c));
   const earliest = periods.reduce((min, p) => p.startDate < min ? p.startDate : min, periods[0].startDate);
-  const since = formatIsoDate(earliest);
+  const since = formatLocalDate(earliest);
   const allTxns = await client.getTransactions(budgetId, { since_date: since, signal });
 
   for (let i = 0; i < trackedCards.length; i++) {
@@ -57,8 +54,8 @@ export async function computeCurrentPeriod(
 
     if (card.subcategoriesEnabled) {
       const simplePeriod = {
-        start: period.startDate.toISOString().split('T')[0],
-        end: period.endDate.toISOString().split('T')[0],
+        start: formatLocalDate(period.startDate),
+        end: formatLocalDate(period.endDate),
         label: period.name,
       };
       const simpleCalc = SimpleRewardsCalculator.calculateCardRewards(card, forCard, simplePeriod, settings);

--- a/apps/web/lib/rewards-engine/date-utils.ts
+++ b/apps/web/lib/rewards-engine/date-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Date helpers tailored for YNAB's local-time date strings.
+ */
+
+/**
+ * Parse a YNAB date string (YYYY-MM-DD) as a local date, preserving the user's timezone.
+ */
+export function parseYnabDate(dateString: string): Date {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/**
+ * Format a local Date as a YNAB-style ISO date string (YYYY-MM-DD) without timezone conversion.
+ */
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Return the last day (1-31) for the provided month of the given year.
+ */
+export function getLastDayOfMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/**
+ * Clamp a requested billing day so it never exceeds the last day of the target month.
+ */
+export function getEffectiveBillingDay(year: number, month: number, requestedDay: number): number {
+  const lastDay = getLastDayOfMonth(year, month);
+  return Math.min(requestedDay, lastDay);
+}

--- a/apps/web/lib/rewards-engine/matcher.ts
+++ b/apps/web/lib/rewards-engine/matcher.ts
@@ -4,6 +4,7 @@
 
 import type { Transaction, TransactionWithRewards } from '@/types/transaction';
 import { absFromMilli } from '@/lib/utils';
+import { parseYnabDate } from './date-utils';
 
 export class TransactionMatcher {
   /**
@@ -28,7 +29,7 @@ export class TransactionMatcher {
     endDate: Date
   ): TransactionWithRewards[] {
     return transactions.filter(txn => {
-      const txnDate = new Date(txn.date);
+      const txnDate = parseYnabDate(txn.date);
       return txnDate >= startDate && txnDate <= endDate;
     });
   }


### PR DESCRIPTION
## Summary

Fixes two critical date handling bugs in the rewards calculation engine:

### 1. Billing Day "31st" Bug

**Problem**: Cards configured to reset on the "31st" would fail in months with fewer days (August, September, February). JavaScript would auto-correct invalid dates like `new Date(2025, 7, 31)` → September 1st, causing billing cycles to skip or overlap incorrectly.

**Fix**: Clamp billing day to the last day of the month. Now setting "31st" means "last day of month" for shorter months:
- August: 30th
- September: 30th  
- February: 28th/29th
- October: actual 31st

This matches how real credit cards work.

### 2. Timezone Conversion Bug

**Problem**: YNAB transaction dates are stored as simple date strings like `"2025-08-15"` (no time component). The code was parsing these with `new Date("2025-08-15")`, which JavaScript interprets as **UTC midnight**, then converts to local timezone. This shifted transactions to different days depending on timezone:
- Singapore (UTC+8): Aug 15 00:00 UTC → Aug 15 08:00 SGT ✓
- California (UTC-8): Aug 15 00:00 UTC → Aug 14 16:00 PDT ✗ (wrong day!)

**Fix**: Parse YNAB dates explicitly in local timezone using `new Date(year, month-1, day)` to match YNAB's behaviour. Also fixed date formatting to use local timezone instead of `.toISOString()`.

## Technical Changes

Created `apps/web/lib/rewards-engine/date-utils.ts` with timezone-aware helpers:
- `parseYnabDate()`: Parse YNAB date strings as local dates
- `formatLocalDate()`: Format dates without UTC conversion
- `getLastDayOfMonth()`: Calculate month length
- `getEffectiveBillingDay()`: Clamp billing day to valid range

Updated calculation logic in:
- `calculator.ts`: Fixed period calculation and transaction filtering
- `simple-calculator.ts`: Fixed period calculation and date formatting  
- `matcher.ts`: Fixed transaction date filtering
- `compute.ts`: Use new date utilities

## Test Plan

- [ ] Verify August billing cycles work correctly for "31st" cards
- [ ] Test in different timezones (SGT, PST, GMT)
- [ ] Verify transactions appear on correct days regardless of timezone
- [ ] Check Feb 28/29 handling for leap years

🤖 Generated with [Claude Code](https://claude.com/claude-code)