### PR TITLE
Refactor rewards engine, dashboard, and storage hooks

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import Link from "next/link";
 import {
   useYnabPAT,
   useCreditCards,
@@ -14,12 +13,7 @@ import {
 import { YnabClient } from "@/lib/ynab-client";
 import { SimpleRewardsCalculator } from "@/lib/rewards-engine";
 import { clampDaysLeft } from "@/lib/date";
-import { cn, absFromMilli } from "@/lib/utils";
 import type { DashboardViewMode } from "@/lib/storage";
-import { CurrencyAmount } from "@/components/CurrencyAmount";
-import { CardSpendingSummary } from "@/components/CardSpendingSummary";
-import { CardSummaryCompact } from "@/components/CardSummaryCompact";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -27,35 +21,17 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
-import { Badge } from "@/components/ui/badge";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import {
-  CheckCircle2,
-  Circle,
-  Wallet,
-  CreditCard,
-  TrendingUp,
-  ArrowRight,
-  AlertCircle,
-  Loader2,
-  Percent,
-  Settings2
-} from "lucide-react";
+import { DashboardLanding } from "@/components/dashboard/DashboardLanding";
+import { SetupProgressAlert } from "@/components/dashboard/SetupProgressAlert";
+import { RulesReminderAlert } from "@/components/dashboard/RulesReminderAlert";
+import { DashboardCardOverview } from "@/components/dashboard/DashboardCardOverview";
+import { DashboardQuickStats } from "@/components/dashboard/DashboardQuickStats";
+import { RecentTransactionsTable } from "@/components/dashboard/RecentTransactionsTable";
 import type { Transaction } from "@/types/transaction";
 
 // Constants
 const TRANSACTION_LOOKBACK_DAYS = 30;
 const RECENT_TRANSACTIONS_LIMIT = 10;
-
-
-// Helper functions
-const createSettingsClickHandler =
-  (cardId: string) => (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    window.location.href = `/cards/${cardId}?tab=settings&edit=1`;
-  };
 
 // Types for better type safety
 
@@ -328,528 +304,42 @@ export default function DashboardPage() {
 
   // Empty state when nothing is configured
   if (!pat) {
-    return (
-      <div className="min-h-[80vh] flex items-center justify-center p-6">
-        <div className="max-w-6xl w-full">
-          <div className="text-center mb-12">
-            <Wallet
-              className="h-16 w-16 text-primary mx-auto mb-4"
-              aria-hidden="true"
-            />
-            <h1 className="text-4xl font-bold mb-2">
-              <span>YJAB</span>
-              <span className="text-muted-foreground font-normal">
-                : YNAB Journal of Awards & Bonuses
-              </span>
-            </h1>
-            <p className="text-xl text-muted-foreground">
-              Maximise your credit card rewards with intelligent tracking
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-2 gap-8 max-w-6xl mx-auto">
-            {/* Features Section */}
-            <Card className="p-8">
-              <CardHeader className="px-0 pt-0">
-                <CardTitle className="text-xl mb-4">Features</CardTitle>
-              </CardHeader>
-              <CardContent className="px-0 pb-0">
-                <ul className="space-y-4">
-                  <li className="flex items-start">
-                    <CheckCircle2
-                      className="h-5 w-5 text-green-500 mr-3 mt-0.5 flex-shrink-0"
-                      aria-hidden="true"
-                    />
-                    <span className="text-foreground">
-                      Automatically calculate rewards based on your actual
-                      spending
-                    </span>
-                  </li>
-                  <li className="flex items-start">
-                    <CheckCircle2
-                      className="h-5 w-5 text-green-500 mr-3 mt-0.5 flex-shrink-0"
-                      aria-hidden="true"
-                    />
-                    <span className="text-foreground">
-                      Track progress toward monthly minimum spend and caps
-                    </span>
-                  </li>
-                  <li className="flex items-start">
-                    <CheckCircle2
-                      className="h-5 w-5 text-green-500 mr-3 mt-0.5 flex-shrink-0"
-                      aria-hidden="true"
-                    />
-                    <span className="text-foreground">
-                      Get recommendations for which card to use for each
-                      purchase
-                    </span>
-                  </li>
-                  <li className="flex items-start">
-                    <CheckCircle2
-                      className="h-5 w-5 text-green-500 mr-3 mt-0.5 flex-shrink-0"
-                      aria-hidden="true"
-                    />
-                    <span className="text-foreground">
-                      100% private — all data stays in your browser
-                    </span>
-                  </li>
-                </ul>
-                <p className="text-sm text-muted-foreground mt-6">
-                  Free to use, with your own paid YNAB subscription.
-                </p>
-              </CardContent>
-            </Card>
-
-            {/* Connection Section */}
-            <Card className="p-8 flex flex-col justify-center border-2">
-              <CardHeader className="px-0 pt-0">
-                <CardTitle className="text-xl mb-2">Get Started</CardTitle>
-                <CardDescription className="text-base">
-                  Connect your YNAB account to start tracking rewards across all
-                  your cards
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="px-0 pb-0">
-                <div className="space-y-4">
-                  <div className="bg-muted/50 rounded-lg p-4">
-                    <p className="text-sm font-medium mb-2">Quick Setup:</p>
-                    <ol className="text-sm text-muted-foreground space-y-1 list-decimal list-inside">
-                      <li>Connect with your Personal Access Token</li>
-                      <li>Select your budget and accounts</li>
-                      <li>Configure your reward cards</li>
-                      <li>Start tracking automatically</li>
-                    </ol>
-                  </div>
-
-                  <Button size="lg" asChild className="w-full">
-                    <Link href="/settings">
-                      <Wallet className="mr-2 h-5 w-5" aria-hidden="true" />
-                      Connect YNAB Account
-                    </Link>
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </div>
-    );
+    return <DashboardLanding />;
   }
 
   return (
     <div className="max-w-6xl mx-auto p-6">
-      {/* Setup Progress */}
       {!isFullyConfigured && (
-        <Alert className="mb-6">
-          <AlertCircle className="h-4 w-4" aria-hidden="true" />
-          <AlertDescription>
-            <div className="mt-2">
-              <div className="flex justify-between items-center mb-3">
-                <span className="font-semibold">
-                  Setup Progress: {setupProgress}/4 steps completed
-                </span>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  asChild
-                  aria-label="Complete setup">
-                  <Link href="/settings">
-                    Complete Setup{" "}
-                    <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
-                  </Link>
-                </Button>
-              </div>
-              <Progress
-                value={setupPercentage}
-                className="mb-3"
-                aria-label={`Setup progress: ${setupProgress} of 4 steps completed`}
-              />
-              <div className="flex gap-4 flex-wrap text-sm">
-                <span className="flex items-center">
-                  {setupStatus.pat ? (
-                    <CheckCircle2
-                      className="h-4 w-4 text-green-500 mr-1"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <Circle
-                      className="h-4 w-4 text-muted-foreground mr-1"
-                      aria-hidden="true"
-                    />
-                  )}
-                  YNAB Token
-                </span>
-                <span className="flex items-center">
-                  {setupStatus.budget ? (
-                    <CheckCircle2
-                      className="h-4 w-4 text-green-500 mr-1"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <Circle
-                      className="h-4 w-4 text-muted-foreground mr-1"
-                      aria-hidden="true"
-                    />
-                  )}
-                  Budget Selected
-                </span>
-                <span className="flex items-center">
-                  {setupStatus.accounts ? (
-                    <CheckCircle2
-                      className="h-4 w-4 text-green-500 mr-1"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <Circle
-                      className="h-4 w-4 text-muted-foreground mr-1"
-                      aria-hidden="true"
-                    />
-                  )}
-                  Accounts Tracked
-                </span>
-                <span className="flex items-center">
-                  {setupStatus.cards ? (
-                    <CheckCircle2
-                      className="h-4 w-4 text-green-500 mr-1"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <Circle
-                      className="h-4 w-4 text-muted-foreground mr-1"
-                      aria-hidden="true"
-                    />
-                  )}
-                  Cards Configured
-                </span>
-              </div>
-            </div>
-          </AlertDescription>
-        </Alert>
+        <SetupProgressAlert
+          setupStatus={setupStatus}
+          setupProgress={setupProgress}
+          setupPercentage={setupPercentage}
+        />
       )}
 
-      {isFullyConfigured &&
-        cards.length > 0 &&
-        rules.length === 0 &&
-        hasUnsetMinimumSpend && (
-          <Alert className="mb-6 border-primary/20 bg-primary/5">
-            <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
-              <span>
-                Nice one—your accounts are synced. Pop over to the Rules page to
-                fine-tune earn rates and optimise your rewards.
-              </span>
-              <Button variant="outline" size="sm" asChild>
-                <Link href="/rules">Go to Rules</Link>
-              </Button>
-            </AlertDescription>
-          </Alert>
-        )}
+      <RulesReminderAlert
+        show={isFullyConfigured && cards.length > 0 && rules.length === 0 && hasUnsetMinimumSpend}
+      />
 
-      {/* Cards Overview */}
-      {cards.length === 0 ? (
-        <Card className="mb-8">
-          <CardHeader>
-            <CardTitle>Your Reward Cards</CardTitle>
-            <CardDescription>
-              Manage your credit cards and their reward rules
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="text-center py-8">
-              <CreditCard
-                className="h-12 w-12 text-muted-foreground mx-auto mb-4"
-                aria-hidden="true"
-              />
-              <p className="text-lg mb-4 text-muted-foreground">
-                No cards configured yet
-              </p>
-              <Button asChild>
-                <Link href="/settings">
-                  <CreditCard className="mr-2 h-4 w-4" aria-hidden="true" />
-                  Add Your First Card
-                </Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-8 mb-8">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div className="flex items-center gap-3">
-              <h2 className="text-2xl font-bold">Your Cards</h2>
-              {hiddenCards.length > 0 && (
-                <div className="flex items-center gap-2">
-                  <Badge variant="secondary">{hiddenCards.length} hidden</Badge>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleUnhideAll}
-                  >
-                    Show all
-                  </Button>
-                </div>
-              )}
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-muted-foreground">View</span>
-              <div className="inline-flex items-center gap-1 rounded-full border border-border/50 bg-background/80 p-1 shadow-inner dark:border-border/40 dark:bg-muted/40">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={viewMode === 'summary' ? 'default' : 'ghost'}
-                  className={cn(
-                    'rounded-full px-3 transition-colors',
-                    viewMode === 'summary'
-                      ? 'shadow-sm'
-                      : 'text-muted-foreground hover:text-primary-foreground hover:bg-primary/80'
-                  )}
-                  onClick={() => handleViewModeChange('summary')}
-                >
-                  Summary
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={viewMode === 'detailed' ? 'default' : 'ghost'}
-                  className={cn(
-                    'rounded-full px-3 transition-colors',
-                    viewMode === 'detailed'
-                      ? 'shadow-sm'
-                      : 'text-muted-foreground hover:text-primary-foreground hover:bg-primary/80'
-                  )}
-                  onClick={() => handleViewModeChange('detailed')}
-                >
-                  Detailed
-                </Button>
-              </div>
-            </div>
-          </div>
+      <DashboardCardOverview
+        cards={cards}
+        cashbackCards={cashbackCards}
+        milesCards={milesCards}
+        visibleFeaturedCards={visibleFeaturedCards}
+        hiddenCards={hiddenCards}
+        viewMode={viewMode}
+        onViewModeChange={handleViewModeChange}
+        onHideCard={handleHideCard}
+        onUnhideAll={handleUnhideAll}
+        pat={pat}
+        prefetchedTransactions={allBudgetTransactions}
+      />
 
-          {visibleFeaturedCards.length === 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>All cards hidden</CardTitle>
-                <CardDescription>
-                  Hidden cards will return when their next billing cycle starts.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="flex flex-col gap-3">
-                <p className="text-muted-foreground">
-                  {hiddenCards.length === 1
-                    ? '1 card is currently hidden.'
-                    : `${hiddenCards.length} cards are currently hidden.`}
-                </p>
-                <Button
-                  variant="outline"
-                  onClick={handleUnhideAll}
-                >
-                  Show hidden cards now
-                </Button>
-              </CardContent>
-            </Card>
-          ) : (
-            <>
-              {/* Cashback Cards */}
-              {cashbackCards.length > 0 && (
-                <div>
-                  <div className="flex items-center gap-2 mb-4">
-                    <Percent className="h-5 w-5 text-green-600" aria-hidden="true" />
-                    <h2 className="text-xl font-semibold">Cashback Cards</h2>
-                    <Badge variant="secondary">{cashbackCards.length}</Badge>
-                  </div>
-                  <div
-                    className={cn(
-                      'grid gap-4',
-                      viewMode === 'detailed'
-                        ? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
-                        : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
-                    )}
-                  >
-                    {cashbackCards.map((card) => {
-                      const accentClasses =
-                        'border border-border/70 dark:border-border/50 hover:border-primary/40';
+      <DashboardQuickStats
+        selectedBudget={selectedBudget}
+        trackedAccountCount={trackedAccountIds.length}
+      />
 
-                      return (
-                        <Link
-                          key={card.id}
-                          href={`/cards/${card.id}`}
-                          className="block group"
-                        >
-                          <Card
-                            className={cn(
-                              'relative overflow-hidden flex flex-col h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-lg',
-                              'bg-card',
-                              accentClasses
-                            )}
-                          >
-                            <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={createSettingsClickHandler(card.id)}
-                                aria-label="Go to card settings"
-                              >
-                                <Settings2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-
-                            <CardHeader className="pb-3">
-                              <CardTitle
-                                title={card.name}
-                                className={cn(
-                                  viewMode === 'detailed' ? 'text-lg' : 'text-[0.95rem] sm:text-base',
-                                  'pr-12 truncate'
-                                )}
-                              >
-                                {card.name}
-                              </CardTitle>
-                            </CardHeader>
-                            <CardContent className="flex-1 flex flex-col">
-                              {viewMode === 'detailed' ? (
-                                <CardSpendingSummary
-                                  card={card}
-                                  pat={pat}
-                                  prefetchedTransactions={allBudgetTransactions}
-                                  onHideCard={handleHideCard}
-                                  showHideOption
-                                />
-                              ) : (
-                                <CardSummaryCompact
-                                  card={card}
-                                  pat={pat}
-                                  prefetchedTransactions={allBudgetTransactions}
-                                  onHideCard={handleHideCard}
-                                />
-                              )}
-                            </CardContent>
-                          </Card>
-                        </Link>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-
-              {/* Miles Cards */}
-              {milesCards.length > 0 && (
-                <div>
-                  <div className="flex items-center gap-2 mb-4">
-                    <TrendingUp className="h-5 w-5 text-blue-600" aria-hidden="true" />
-                    <h2 className="text-xl font-semibold">Miles Cards</h2>
-                    <Badge variant="secondary">{milesCards.length}</Badge>
-                  </div>
-                  <div
-                    className={cn(
-                      'grid gap-4',
-                      viewMode === 'detailed'
-                        ? 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
-                        : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
-                    )}
-                  >
-                    {milesCards.map((card) => {
-                      const accentClasses =
-                        'border border-border/70 dark:border-border/50 hover:border-primary/40';
-
-                      return (
-                        <Link
-                          key={card.id}
-                          href={`/cards/${card.id}`}
-                          className="block group"
-                        >
-                          <Card
-                            className={cn(
-                              'relative overflow-hidden flex flex-col h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-lg',
-                              'bg-card',
-                              accentClasses
-                            )}
-                          >
-                            <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
-                                onClick={createSettingsClickHandler(card.id)}
-                                aria-label="Go to card settings"
-                              >
-                                <Settings2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-
-                            <CardHeader className="pb-3">
-                              <CardTitle
-                                title={card.name}
-                                className={cn(
-                                  viewMode === 'detailed' ? 'text-lg' : 'text-[0.95rem] sm:text-base',
-                                  'pr-12 truncate'
-                                )}
-                              >
-                                {card.name}
-                              </CardTitle>
-                            </CardHeader>
-                            <CardContent className="flex-1 flex flex-col">
-                              {viewMode === 'detailed' ? (
-                                <CardSpendingSummary
-                                  card={card}
-                                  pat={pat}
-                                  prefetchedTransactions={allBudgetTransactions}
-                                  onHideCard={handleHideCard}
-                                  showHideOption
-                                />
-                              ) : (
-                                <CardSummaryCompact
-                                  card={card}
-                                  pat={pat}
-                                  prefetchedTransactions={allBudgetTransactions}
-                                  onHideCard={handleHideCard}
-                                />
-                              )}
-                            </CardContent>
-                          </Card>
-                        </Link>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      )}
-
-      {/* Quick Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Active Budget</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-xl font-bold truncate">
-              {selectedBudget.name || "None Selected"}
-            </p>
-            {selectedBudget.id && (
-              <Button variant="link" size="sm" asChild className="px-0">
-                <Link href="/settings#settings-budget">Change</Link>
-              </Button>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Tracked Accounts
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-bold">{trackedAccountIds.length}</p>
-            <Button variant="link" size="sm" asChild className="px-0">
-              <Link href="/settings#settings-accounts">Manage</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Recent Transactions Preview */}
       {isFullyConfigured && (
         <Card className="mb-8">
           <CardHeader>
@@ -861,79 +351,13 @@ export default function DashboardPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            {loading && (
-              <div className="flex items-center justify-center py-8">
-                <Loader2
-                  className="h-8 w-8 animate-spin text-muted-foreground"
-                  aria-hidden="true"
-                />
-                <span className="ml-2">Loading transactions...</span>
-              </div>
-            )}
-            {error && (
-              <Alert variant="destructive">
-                <AlertCircle className="h-4 w-4" aria-hidden="true" />
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
-            {!loading && !error && transactions.length > 0 && (
-              <div className="overflow-x-auto">
-                <table
-                  className="w-full"
-                  role="table"
-                  aria-label="Recent transactions">
-                  <thead>
-                    <tr className="border-b" role="row">
-                      <th className="text-left p-2 font-medium" scope="col">
-                        Date
-                      </th>
-                      <th className="text-left p-2 font-medium" scope="col">
-                        Account
-                      </th>
-                      <th className="text-left p-2 font-medium" scope="col">
-                        Payee
-                      </th>
-                      <th className="text-left p-2 font-medium" scope="col">
-                        Category
-                      </th>
-                      <th className="text-right p-2 font-medium" scope="col">
-                        Amount
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {transactions.map((txn, index) => (
-                      <tr
-                        key={txn.id}
-                        className={cn(
-                          "border-b",
-                          index % 2 === 0 ? "bg-transparent" : "bg-muted/30"
-                        )}
-                        role="row">
-                        <td className="p-2 text-sm">
-                          {new Date(txn.date).toLocaleDateString()}
-                        </td>
-                        <td className="p-2 text-sm font-medium">
-                          {accountsMap.get(txn.account_id) || "Unknown"}
-                        </td>
-                        <td className="p-2 text-sm">{txn.payee_name}</td>
-                        <td className="p-2 text-sm">
-                          {txn.category_name || "Uncategorised"}
-                        </td>
-                        <td className="p-2 text-sm text-right font-mono">
-                          <CurrencyAmount value={absFromMilli(txn.amount)} />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-            {!loading && !error && transactions.length === 0 && (
-              <p className="text-center py-8 text-muted-foreground">
-                No recent transactions found.
-              </p>
-            )}
+            <RecentTransactionsTable
+              loading={loading}
+              error={error}
+              transactions={transactions}
+              accountsMap={accountsMap}
+              lookbackDays={TRANSACTION_LOOKBACK_DAYS}
+            />
           </CardContent>
         </Card>
       )}

--- a/apps/web/components/dashboard/DashboardCardOverview.tsx
+++ b/apps/web/components/dashboard/DashboardCardOverview.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import Link from "next/link";
+import type { MouseEvent, ReactNode } from "react";
+import { useMemo, useCallback } from "react";
+import { CreditCard as CreditCardIcon, Percent, Settings2, TrendingUp } from "lucide-react";
+
+import type {
+  CreditCard,
+  DashboardViewMode,
+  HiddenCard,
+} from "@/lib/storage";
+import type { Transaction } from "@/types/transaction";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { CardSpendingSummary } from "@/components/CardSpendingSummary";
+import { CardSummaryCompact } from "@/components/CardSummaryCompact";
+
+interface DashboardCardOverviewProps {
+  cards: CreditCard[];
+  cashbackCards: CreditCard[];
+  milesCards: CreditCard[];
+  visibleFeaturedCards: CreditCard[];
+  hiddenCards: HiddenCard[];
+  viewMode: DashboardViewMode;
+  onViewModeChange(mode: DashboardViewMode): void;
+  onHideCard(cardId: string, hiddenUntil: string): void;
+  onUnhideAll(): void;
+  pat: string;
+  prefetchedTransactions: Transaction[];
+}
+
+function createSettingsClickHandler(cardId: string) {
+  return (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    window.location.href = `/cards/${cardId}?tab=settings&edit=1`;
+  };
+}
+
+export function DashboardCardOverview({
+  cards,
+  cashbackCards,
+  milesCards,
+  visibleFeaturedCards,
+  hiddenCards,
+  viewMode,
+  onViewModeChange,
+  onHideCard,
+  onUnhideAll,
+  pat,
+  prefetchedTransactions,
+}: DashboardCardOverviewProps) {
+  const hiddenCount = hiddenCards.length;
+  const hasVisibleCards = visibleFeaturedCards.length > 0;
+
+  const handleShowAll = useCallback(() => {
+    onUnhideAll();
+  }, [onUnhideAll]);
+
+  const handleViewChange = useCallback(
+    (mode: DashboardViewMode) => () => onViewModeChange(mode),
+    [onViewModeChange]
+  );
+
+  const summaryContent = useMemo(() => {
+    if (cards.length === 0) {
+      return (
+        <Card className="mb-8">
+          <CardHeader>
+            <CardTitle>Your Reward Cards</CardTitle>
+            <CardDescription>Manage your credit cards and their reward rules</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-center py-8">
+              <CreditCardIcon className="h-12 w-12 text-muted-foreground mx-auto mb-4" aria-hidden="true" />
+              <p className="text-lg mb-4 text-muted-foreground">No cards configured yet</p>
+              <Button asChild>
+                <Link href="/settings">
+                  <CreditCardIcon className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Add Your First Card
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    if (!hasVisibleCards) {
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle>All cards hidden</CardTitle>
+            <CardDescription>Hidden cards will return when their next billing cycle starts.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <p className="text-muted-foreground">
+              {hiddenCount === 1 ? "1 card is currently hidden." : `${hiddenCount} cards are currently hidden.`}
+            </p>
+            <Button variant="outline" onClick={handleShowAll}>
+              Show hidden cards now
+            </Button>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return (
+      <>
+        {cashbackCards.length > 0 && (
+          <CardGroup
+            title="Cashback Cards"
+            icon={<Percent className="h-5 w-5 text-green-600" aria-hidden="true" />}
+            cards={cashbackCards}
+            viewMode={viewMode}
+            pat={pat}
+            prefetchedTransactions={prefetchedTransactions}
+            onHideCard={onHideCard}
+          />
+        )}
+        {milesCards.length > 0 && (
+          <CardGroup
+            title="Miles Cards"
+            icon={<TrendingUp className="h-5 w-5 text-blue-600" aria-hidden="true" />}
+            cards={milesCards}
+            viewMode={viewMode}
+            pat={pat}
+            prefetchedTransactions={prefetchedTransactions}
+            onHideCard={onHideCard}
+          />
+        )}
+      </>
+    );
+  }, [cards.length, hasVisibleCards, cashbackCards, viewMode, pat, prefetchedTransactions, onHideCard, milesCards, hiddenCount, handleShowAll]);
+
+  return (
+    <div className="space-y-8 mb-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3">
+          <h2 className="text-2xl font-bold">Your Cards</h2>
+          {hiddenCount > 0 && (
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">{hiddenCount} hidden</Badge>
+              <Button variant="outline" size="sm" onClick={handleShowAll}>
+                Show all
+              </Button>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">View</span>
+          <div className="inline-flex items-center gap-1 rounded-full border border-border/50 bg-background/80 p-1 shadow-inner dark:border-border/40 dark:bg-muted/40">
+            <Button
+              type="button"
+              size="sm"
+              variant={viewMode === "summary" ? "default" : "ghost"}
+              className={cn(
+                "rounded-full px-3 transition-colors",
+                viewMode === "summary"
+                  ? "shadow-sm"
+                  : "text-muted-foreground hover:text-primary-foreground hover:bg-primary/80"
+              )}
+              onClick={handleViewChange("summary")}
+            >
+              Summary
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={viewMode === "detailed" ? "default" : "ghost"}
+              className={cn(
+                "rounded-full px-3 transition-colors",
+                viewMode === "detailed"
+                  ? "shadow-sm"
+                  : "text-muted-foreground hover:text-primary-foreground hover:bg-primary/80"
+              )}
+              onClick={handleViewChange("detailed")}
+            >
+              Detailed
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {summaryContent}
+    </div>
+  );
+}
+
+interface CardGroupProps {
+  title: string;
+  icon: ReactNode;
+  cards: CreditCard[];
+  viewMode: DashboardViewMode;
+  pat: string;
+  prefetchedTransactions: Transaction[];
+  onHideCard(cardId: string, hiddenUntil: string): void;
+}
+
+function CardGroup({ title, icon, cards, viewMode, pat, prefetchedTransactions, onHideCard }: CardGroupProps) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4">
+        {icon}
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <Badge variant="secondary">{cards.length}</Badge>
+      </div>
+      <div
+        className={cn(
+          "grid gap-4",
+          viewMode === "detailed"
+            ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        )}
+      >
+        {cards.map((card) => {
+          const accentClasses = "border border-border/70 dark:border-border/50 hover:border-primary/40";
+
+          return (
+            <Link key={card.id} href={`/cards/${card.id}`} className="block group">
+              <Card
+                className={cn(
+                  "relative overflow-hidden flex flex-col h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-lg",
+                  "bg-card",
+                  accentClasses
+                )}
+              >
+                <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={createSettingsClickHandler(card.id)}
+                    aria-label="Go to card settings"
+                  >
+                    <Settings2 className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                <CardHeader className="pb-3">
+                  <CardTitle
+                    title={card.name}
+                    className={cn(
+                      viewMode === "detailed" ? "text-lg" : "text-[0.95rem] sm:text-base",
+                      "pr-12 truncate"
+                    )}
+                  >
+                    {card.name}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex-1 flex flex-col">
+                  {viewMode === "detailed" ? (
+                    <CardSpendingSummary
+                      card={card}
+                      pat={pat}
+                      prefetchedTransactions={prefetchedTransactions}
+                      onHideCard={onHideCard}
+                      showHideOption
+                    />
+                  ) : (
+                    <CardSummaryCompact
+                      card={card}
+                      pat={pat}
+                      prefetchedTransactions={prefetchedTransactions}
+                      onHideCard={onHideCard}
+                    />
+                  )}
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/DashboardLanding.tsx
+++ b/apps/web/components/dashboard/DashboardLanding.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { Wallet, CheckCircle2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function DashboardLanding() {
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center p-6">
+      <div className="max-w-6xl w-full">
+        <div className="text-center mb-12">
+          <Wallet className="h-16 w-16 text-primary mx-auto mb-4" aria-hidden="true" />
+          <h1 className="text-4xl font-bold mb-2">
+            <span>YJAB</span>
+            <span className="text-muted-foreground font-normal">
+              : YNAB Journal of Awards & Bonuses
+            </span>
+          </h1>
+          <p className="text-xl text-muted-foreground">
+            Maximise your credit card rewards with intelligent tracking
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-8 max-w-6xl mx-auto">
+          <Card className="p-8">
+            <CardHeader className="px-0 pt-0">
+              <CardTitle className="text-xl mb-4">Features</CardTitle>
+            </CardHeader>
+            <CardContent className="px-0 pb-0">
+              <ul className="space-y-4">
+                {[
+                  "Automatically calculate rewards based on your actual spending",
+                  "Track progress toward monthly minimum spend and caps",
+                  "Get recommendations for which card to use for each purchase",
+                  "100% private — all data stays in your browser",
+                ].map((text) => (
+                  <li key={text} className="flex items-start">
+                    <CheckCircle2
+                      className="h-5 w-5 text-green-500 mr-3 mt-0.5 flex-shrink-0"
+                      aria-hidden="true"
+                    />
+                    <span className="text-foreground">{text}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-sm text-muted-foreground mt-6">
+                Free to use, with your own paid YNAB subscription.
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card className="p-8 flex flex-col justify-center border-2">
+            <CardHeader className="px-0 pt-0">
+              <CardTitle className="text-xl mb-2">Get Started</CardTitle>
+              <CardDescription className="text-base">
+                Connect your YNAB account to start tracking rewards across all your cards
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="px-0 pb-0">
+              <div className="space-y-4">
+                <div className="bg-muted/50 rounded-lg p-4">
+                  <p className="text-sm font-medium mb-2">Quick Setup:</p>
+                  <ol className="text-sm text-muted-foreground space-y-1 list-decimal list-inside">
+                    <li>Connect with your Personal Access Token</li>
+                    <li>Select your budget and accounts</li>
+                    <li>Configure your reward cards</li>
+                    <li>Start tracking automatically</li>
+                  </ol>
+                </div>
+
+                <Button size="lg" asChild className="w-full">
+                  <Link href="/settings">
+                    <Wallet className="mr-2 h-5 w-5" aria-hidden="true" />
+                    Connect YNAB Account
+                  </Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/DashboardQuickStats.tsx
+++ b/apps/web/components/dashboard/DashboardQuickStats.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface DashboardQuickStatsProps {
+  selectedBudget: {
+    id?: string;
+    name?: string;
+  };
+  trackedAccountCount: number;
+}
+
+export function DashboardQuickStats({ selectedBudget, trackedAccountCount }: DashboardQuickStatsProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Active Budget</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xl font-bold truncate">{selectedBudget.name || "None Selected"}</p>
+          {selectedBudget.id && (
+            <Button variant="link" size="sm" asChild className="px-0">
+              <Link href="/settings#settings-budget">Change</Link>
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Tracked Accounts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-3xl font-bold">{trackedAccountCount}</p>
+          <Button variant="link" size="sm" asChild className="px-0">
+            <Link href="/settings#settings-accounts">Manage</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/RecentTransactionsTable.tsx
+++ b/apps/web/components/dashboard/RecentTransactionsTable.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { AlertCircle, Loader2 } from "lucide-react";
+
+import type { Transaction } from "@/types/transaction";
+import { CurrencyAmount } from "@/components/CurrencyAmount";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { cn, absFromMilli as absFromMilliFn } from "@/lib/utils";
+
+interface RecentTransactionsTableProps {
+  loading: boolean;
+  error: string;
+  transactions: Transaction[];
+  accountsMap: Map<string, string>;
+  lookbackDays: number;
+}
+
+export function RecentTransactionsTable({ loading, error, transactions, accountsMap, lookbackDays }: RecentTransactionsTableProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" aria-hidden="true" />
+        <span className="ml-2">Loading transactions...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" aria-hidden="true" />
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (transactions.length === 0) {
+    return <p className="text-center py-8 text-muted-foreground">No recent transactions found.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full" role="table" aria-label={`Recent transactions (Last ${lookbackDays} Days)`}>
+        <thead>
+          <tr className="border-b" role="row">
+            <th className="text-left p-2 font-medium" scope="col">
+              Date
+            </th>
+            <th className="text-left p-2 font-medium" scope="col">
+              Account
+            </th>
+            <th className="text-left p-2 font-medium" scope="col">
+              Payee
+            </th>
+            <th className="text-left p-2 font-medium" scope="col">
+              Category
+            </th>
+            <th className="text-right p-2 font-medium" scope="col">
+              Amount
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map((txn, index) => (
+            <tr
+              key={txn.id}
+              className={cn("border-b", index % 2 === 0 ? "bg-transparent" : "bg-muted/30")}
+              role="row"
+            >
+              <td className="p-2 text-sm">{new Date(txn.date).toLocaleDateString()}</td>
+              <td className="p-2 text-sm font-medium">{accountsMap.get(txn.account_id) || "Unknown"}</td>
+              <td className="p-2 text-sm">{txn.payee_name}</td>
+              <td className="p-2 text-sm">{txn.category_name || "Uncategorised"}</td>
+              <td className="p-2 text-sm text-right font-mono">
+                <CurrencyAmount value={absFromMilliFn(txn.amount)} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/RulesReminderAlert.tsx
+++ b/apps/web/components/dashboard/RulesReminderAlert.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+interface RulesReminderAlertProps {
+  show: boolean;
+}
+
+export function RulesReminderAlert({ show }: RulesReminderAlertProps) {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <Alert className="mb-6 border-primary/20 bg-primary/5">
+      <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+        <span>
+          Nice one—your accounts are synced. Pop over to the Rules page to fine-tune earn rates and optimise your rewards.
+        </span>
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/rules">Go to Rules</Link>
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/components/dashboard/SetupProgressAlert.tsx
+++ b/apps/web/components/dashboard/SetupProgressAlert.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, Circle } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+
+interface SetupProgressAlertProps {
+  setupStatus: {
+    pat: boolean;
+    budget: boolean;
+    accounts: boolean;
+    cards: boolean;
+  };
+  setupProgress: number;
+  setupPercentage: number;
+}
+
+export function SetupProgressAlert({ setupStatus, setupProgress, setupPercentage }: SetupProgressAlertProps) {
+  return (
+    <Alert className="mb-6">
+      <AlertDescription>
+        <div className="mt-2">
+          <div className="flex justify-between items-center mb-3">
+            <span className="font-semibold">Setup Progress: {setupProgress}/4 steps completed</span>
+            <Button variant="outline" size="sm" asChild aria-label="Complete setup">
+              <Link href="/settings">
+                Complete Setup
+                <ArrowRight className="ml-1 h-4 w-4" aria-hidden="true" />
+              </Link>
+            </Button>
+          </div>
+          <Progress
+            value={setupPercentage}
+            className="mb-3"
+            aria-label={`Setup progress: ${setupProgress} of 4 steps completed`}
+          />
+          <div className="flex gap-4 flex-wrap text-sm">
+            {[
+              { label: "YNAB Token", complete: setupStatus.pat },
+              { label: "Budget Selected", complete: setupStatus.budget },
+              { label: "Accounts Tracked", complete: setupStatus.accounts },
+              { label: "Cards Configured", complete: setupStatus.cards },
+            ].map(({ label, complete }) => (
+              <span key={label} className="flex items-center">
+                {complete ? (
+                  <CheckCircle2 className="h-4 w-4 text-green-500 mr-1" aria-hidden="true" />
+                ) : (
+                  <Circle className="h-4 w-4 text-muted-foreground mr-1" aria-hidden="true" />
+                )}
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/lib/rewards-engine/compute.ts
+++ b/apps/web/lib/rewards-engine/compute.ts
@@ -9,21 +9,14 @@ import { RewardsCalculator } from './calculator';
 import { SimpleRewardsCalculator } from './simple-calculator';
 import { TransactionMatcher } from './matcher';
 import { formatLocalDate } from './date-utils';
+import { periodOverlapsWindow } from './utils/periods';
+import { createRewardCalculationFromSimple } from './utils/reward-calculation';
 import type {
   AppSettings,
   CreditCard,
   RewardCalculation,
   RewardRule,
 } from '@/lib/storage';
-
-function periodOverlapsWindow(periodStart: Date, periodEnd: Date, start?: string, end?: string): boolean {
-  const windowStart = start ? new Date(start) : undefined;
-  const windowEnd = end ? new Date(end) : undefined;
-
-  if (windowStart && periodEnd < windowStart) return false;
-  if (windowEnd && periodStart > windowEnd) return false;
-  return true;
-}
 
 export async function computeCurrentPeriod(
   pat: string,
@@ -59,33 +52,7 @@ export async function computeCurrentPeriod(
         label: period.name,
       };
       const simpleCalc = SimpleRewardsCalculator.calculateCardRewards(card, forCard, simplePeriod, settings);
-      results.push({
-        cardId: card.id,
-        ruleId: `card-${card.id}`,
-        period: period.name,
-        totalSpend: simpleCalc.totalSpend,
-        eligibleSpend: simpleCalc.eligibleSpend,
-        rewardEarned: simpleCalc.rewardEarned,
-        rewardEarnedDollars: simpleCalc.rewardEarnedDollars,
-        rewardType: simpleCalc.rewardType,
-        minimumProgress: simpleCalc.minimumSpendProgress,
-        maximumProgress: simpleCalc.maximumSpendProgress,
-        minimumMet: simpleCalc.minimumSpendMet,
-        maximumExceeded: simpleCalc.maximumSpendExceeded,
-        shouldStopUsing: simpleCalc.maximumSpendExceeded,
-        subcategoryBreakdowns: simpleCalc.subcategoryBreakdowns?.map((sub) => ({
-          subcategoryId: sub.id,
-          name: sub.name,
-          flagColor: sub.flagColor,
-          totalSpend: sub.totalSpend,
-          eligibleSpend: sub.eligibleSpend,
-          eligibleSpendBeforeBlocks: sub.eligibleSpendBeforeBlocks,
-          rewardEarned: sub.rewardEarned,
-          rewardEarnedDollars: sub.rewardEarnedDollars,
-          minimumSpendMet: sub.minimumSpendMet,
-          maximumSpendExceeded: sub.maximumSpendExceeded,
-        })),
-      });
+      results.push(createRewardCalculationFromSimple(card, simpleCalc));
       continue;
     }
 

--- a/apps/web/lib/rewards-engine/index.ts
+++ b/apps/web/lib/rewards-engine/index.ts
@@ -13,4 +13,4 @@ export type {
   CardRecommendation,
   CategoryCardInsight,
   CategoryRecommendation,
-} from './recommendations';
+} from './types';

--- a/apps/web/lib/rewards-engine/recommendations.ts
+++ b/apps/web/lib/rewards-engine/recommendations.ts
@@ -6,6 +6,7 @@ import type { RewardCalculation, CreditCard, AppSettings, ThemeGroup } from '@/l
 
 import type { CardRecommendation, CategoryCardInsight, CategoryRecommendation } from './types';
 import { buildCardEntries, createSubcategoryInsight, createWholeCardInsight } from './utils/category-insights';
+import { getAlertRecommendations, getCardRecommendations } from './utils/card-recommendations';
 
 export class RecommendationEngine {
   /**
@@ -15,76 +16,7 @@ export class RecommendationEngine {
     cards: CreditCard[],
     calculations: RewardCalculation[]
   ): CardRecommendation[] {
-    const recommendations: CardRecommendation[] = [];
-
-    cards.forEach(card => {
-      const cardCalculations = calculations.filter(calc => calc.cardId === card.id);
-      
-      if (cardCalculations.length === 0) {
-        recommendations.push({
-          cardId: card.id,
-          cardName: card.name,
-          reason: 'No activity this period',
-          priority: 'low',
-          action: 'consider'
-        });
-        return;
-      }
-
-      // Check for cards that should be avoided
-      const shouldAvoid = cardCalculations.some(calc => calc.shouldStopUsing);
-      if (shouldAvoid) {
-        recommendations.push({
-          cardId: card.id,
-          cardName: card.name,
-          reason: 'Maximum spending limit reached',
-          priority: 'high',
-          action: 'avoid'
-        });
-        return;
-      }
-
-      // Check for cards close to minimum requirements
-      const needsMoreSpend = cardCalculations.some(calc => 
-        calc.minimumProgress !== undefined && 
-        calc.minimumProgress < 100 && 
-        calc.minimumProgress > 50
-      );
-
-      if (needsMoreSpend) {
-        recommendations.push({
-          cardId: card.id,
-          cardName: card.name,
-          reason: 'Close to meeting minimum spend requirement',
-          priority: 'medium',
-          action: 'use'
-        });
-        return;
-      }
-
-      // Check for cards with good reward rates using normalized dollar values
-      const avgRewardRate = cardCalculations.reduce((sum, calc) => {
-        // Use normalized dollars for consistent comparison across card types
-        const rewardDollars = calc.rewardEarnedDollars || calc.rewardEarned;
-        return sum + (calc.eligibleSpend > 0 ? rewardDollars / calc.eligibleSpend : 0);
-      }, 0) / cardCalculations.length;
-
-      if (avgRewardRate > 0.02) { // >2% effective rate
-        recommendations.push({
-          cardId: card.id,
-          cardName: card.name,
-          reason: `Good reward rate (${(avgRewardRate * 100).toFixed(1)}%)`,
-          priority: 'medium',
-          action: 'use'
-        });
-      }
-    });
-
-    // Sort by priority
-    const priorityOrder = { high: 3, medium: 2, low: 1 };
-    return recommendations.sort((a, b) => 
-      priorityOrder[b.priority] - priorityOrder[a.priority]
-    );
+    return getCardRecommendations(cards, calculations);
   }
 
   static generateCategoryRecommendations(
@@ -185,35 +117,6 @@ export class RecommendationEngine {
     cards: CreditCard[],
     calculations: RewardCalculation[]
   ): CardRecommendation[] {
-    const alerts: CardRecommendation[] = [];
-
-    calculations.forEach(calc => {
-      const card = cards.find(c => c.id === calc.cardId);
-      if (!card) return;
-
-      // Alert for maximum reached
-      if (calc.shouldStopUsing) {
-        alerts.push({
-          cardId: card.id,
-          cardName: card.name,
-          reason: 'Stop using - maximum spend reached',
-          priority: 'high',
-          action: 'avoid'
-        });
-      }
-
-      // Alert for minimum not met (with deadline approaching)
-      if (calc.minimumProgress !== undefined && calc.minimumProgress < 80) {
-        alerts.push({
-          cardId: card.id,
-          cardName: card.name,
-          reason: `Only ${Math.round(calc.minimumProgress)}% of minimum spend`,
-          priority: 'medium',
-          action: 'use'
-        });
-      }
-    });
-
-    return alerts;
+    return getAlertRecommendations(cards, calculations);
   }
 }

--- a/apps/web/lib/rewards-engine/recommendations.ts
+++ b/apps/web/lib/rewards-engine/recommendations.ts
@@ -2,58 +2,10 @@
  * Smart recommendations for card usage
  */
 
-import type {
-  RewardCalculation,
-  CreditCard,
-  AppSettings,
-  ThemeGroup,
-  SubcategoryBreakdown,
-  CardSubcategory,
-  SubcategoryReference,
-} from '@/lib/storage';
+import type { RewardCalculation, CreditCard, AppSettings, ThemeGroup } from '@/lib/storage';
 
-export interface CardRecommendation {
-  cardId: string;
-  cardName: string;
-  reason: string;
-  priority: 'high' | 'medium' | 'low';
-  action: 'use' | 'avoid' | 'consider';
-}
-
-export interface CategoryCardInsight {
-  cardId: string;
-  cardName: string;
-  cardType: CreditCard['type'];
-  rewardRate: number;
-  rewardEarnedDollars: number;
-  totalSpend: number;
-  eligibleSpend: number;
-  eligibleSpendBeforeBlocks: number;
-  hasData: boolean;
-  minimumMet: boolean;
-  minimumProgress?: number | null;
-  minimumTarget?: number | null;
-  minimumRemaining?: number | null;
-  cardMinimumMet: boolean;
-  cardMinimumProgress?: number | null;
-  maximumCap?: number | null;
-  maximumProgress?: number | null;
-  headroomToMaximum?: number | null;
-  cardMaximumProgress?: number | null;
-  cardMaximumCap?: number | null;
-  cardMaximumExceeded: boolean;
-  status: 'use' | 'consider' | 'avoid';
-  shouldAvoid: boolean;
-  notes?: string[];
-}
-
-export interface CategoryRecommendation {
-  groupId: string;
-  groupName: string;
-  groupDescription?: string;
-  latestPeriod?: string;
-  insights: CategoryCardInsight[];
-}
+import type { CardRecommendation, CategoryCardInsight, CategoryRecommendation } from './types';
+import { buildCardEntries, createSubcategoryInsight, createWholeCardInsight } from './utils/category-insights';
 
 export class RecommendationEngine {
   /**
@@ -178,107 +130,7 @@ export class RecommendationEngine {
     return [...groups]
       .sort((a, b) => a.priority - b.priority)
       .map((group) => {
-        const cardEntries = new Map<string, { refs: SubcategoryReference[]; includeWhole: boolean }>();
-
-        group.subcategories.forEach((ref) => {
-          if (!ref?.cardId || !ref?.subcategoryId) {
-            return;
-          }
-          const entry = cardEntries.get(ref.cardId);
-          if (entry) {
-            entry.refs.push(ref);
-          } else {
-            cardEntries.set(ref.cardId, { refs: [ref], includeWhole: false });
-          }
-        });
-
-        (group.cards ?? []).forEach((ref) => {
-          if (!ref?.cardId) {
-            return;
-          }
-          const entry = cardEntries.get(ref.cardId);
-          if (entry) {
-            if (entry.refs.length === 0) {
-              entry.includeWhole = true;
-            }
-          } else {
-            cardEntries.set(ref.cardId, { refs: [], includeWhole: true });
-          }
-        });
-
-        const buildCardInsight = (card: CreditCard, calculation: RewardCalculation | undefined): CategoryCardInsight => {
-          const totalSpend = calculation?.totalSpend ?? 0;
-          const eligibleSpend = calculation?.eligibleSpend ?? 0;
-          const eligibleSpendBeforeBlocks = calculation?.eligibleSpend ?? eligibleSpend;
-
-          let rewardEarnedDollars = calculation?.rewardEarnedDollars;
-          if (rewardEarnedDollars == null && calculation) {
-            rewardEarnedDollars = calculation.rewardType === 'cashback'
-              ? calculation.rewardEarned
-              : (calculation.rewardEarned ?? 0) * milesValuation;
-          }
-          rewardEarnedDollars = rewardEarnedDollars ?? 0;
-
-          const minimumTarget = typeof card.minimumSpend === 'number' && card.minimumSpend > 0
-            ? card.minimumSpend
-            : null;
-          const cardMinimumProgress = calculation?.minimumProgress ?? (minimumTarget
-            ? Math.min(100, (totalSpend / minimumTarget) * 100)
-            : null);
-          const minimumRemaining = minimumTarget ? Math.max(0, minimumTarget - totalSpend) : null;
-          const cardMinimumMet = calculation?.minimumMet ?? (minimumTarget ? totalSpend >= minimumTarget : true);
-
-          const maximumCap = typeof card.maximumSpend === 'number' && card.maximumSpend > 0
-            ? card.maximumSpend
-            : null;
-          const spentTowardsCap = calculation?.eligibleSpend ?? eligibleSpend;
-          const cardMaximumProgress = calculation?.maximumProgress ?? (maximumCap
-            ? Math.min(100, (spentTowardsCap / maximumCap) * 100)
-            : null);
-          const headroomToMaximum = maximumCap ? Math.max(0, maximumCap - spentTowardsCap) : null;
-          const cardMaximumExceeded = calculation?.maximumExceeded ?? Boolean(maximumCap && headroomToMaximum !== null && headroomToMaximum <= 0);
-
-          const hasData = totalSpend > 0 || eligibleSpend > 0;
-
-          const fallbackRate = card.type === 'cashback'
-            ? ((card.earningRate ?? 0) / 100)
-            : ((card.earningRate ?? 0) * milesValuation);
-
-          const rewardRate = totalSpend > 0
-            ? rewardEarnedDollars / totalSpend
-            : fallbackRate;
-
-          const shouldAvoid = Boolean(calculation?.shouldStopUsing) || cardMaximumExceeded;
-          const status: 'use' | 'consider' | 'avoid' = shouldAvoid
-            ? 'avoid'
-            : (!cardMinimumMet ? 'consider' : 'use');
-
-          return {
-            cardId: card.id,
-            cardName: card.name,
-            cardType: card.type,
-            rewardRate,
-            rewardEarnedDollars,
-            totalSpend,
-            eligibleSpend,
-            eligibleSpendBeforeBlocks,
-            hasData,
-            minimumMet: cardMinimumMet,
-            minimumProgress: cardMinimumProgress,
-            minimumTarget,
-            minimumRemaining,
-            cardMinimumMet,
-            cardMinimumProgress,
-            maximumCap,
-            maximumProgress: cardMaximumProgress,
-            headroomToMaximum,
-            cardMaximumProgress,
-            cardMaximumCap: maximumCap,
-            cardMaximumExceeded,
-            status,
-            shouldAvoid,
-          };
-        };
+        const cardEntries = buildCardEntries(group);
 
         const insights: CategoryCardInsight[] = [];
 
@@ -288,174 +140,24 @@ export class RecommendationEngine {
             return;
           }
 
-          if (entry.refs.length === 0 && entry.includeWhole) {
-            insights.push(buildCardInsight(card, calcByCard.get(cardId)));
-            return;
-          }
+          const calculation = calcByCard.get(cardId);
 
           if (entry.refs.length === 0) {
-            return;
-          }
-
-          const cardSubcategories = Array.isArray(card.subcategories) ? card.subcategories : [];
-          if (!card.subcategoriesEnabled || cardSubcategories.length === 0) {
             if (entry.includeWhole) {
-              insights.push(buildCardInsight(card, calcByCard.get(cardId)));
+              insights.push(createWholeCardInsight(card, calculation, milesValuation));
             }
             return;
           }
 
-          const subcategoryMap = new Map<string, CardSubcategory>();
-          cardSubcategories.forEach((sub) => {
-            if (sub && typeof sub.id === 'string') {
-              subcategoryMap.set(sub.id, sub);
-            }
-          });
-
-          const calculation = calcByCard.get(cardId);
-          const breakdownMap = new Map<string, SubcategoryBreakdown>();
-          calculation?.subcategoryBreakdowns?.forEach((breakdown) => {
-            breakdownMap.set(breakdown.subcategoryId, breakdown);
-          });
-
-          let totalSpend = 0;
-          let eligibleSpend = 0;
-          let eligibleBeforeBlocksTotal = 0;
-          let rewardEarnedDollars = 0;
-
-          let minimumTargetSum = 0;
-          let minimumProgressNumerator = 0;
-          let minimumRemainingTotal = 0;
-
-          let maximumCapSum = 0;
-          let maximumProgressNumerator = 0;
-          let minHeadroom = Number.POSITIVE_INFINITY;
-          let hasMaximumConstraint = false;
-          let maxExceeded = false;
-
-          let hasData = false;
-
-          entry.refs.forEach((ref) => {
-            const subDefinition = subcategoryMap.get(ref.subcategoryId);
-            if (!subDefinition || subDefinition.active === false || subDefinition.excludeFromRewards) {
-              return;
-            }
-            const breakdown = breakdownMap.get(ref.subcategoryId);
-            const spend = breakdown?.totalSpend ?? 0;
-            const eligible = breakdown?.eligibleSpend ?? 0;
-            const eligibleBefore = breakdown?.eligibleSpendBeforeBlocks ?? eligible;
-            const rewardDollars = breakdown?.rewardEarnedDollars ??
-              (card.type === 'cashback'
-                ? breakdown?.rewardEarned ?? 0
-                : (breakdown?.rewardEarned ?? 0) * milesValuation);
-
-            if (spend > 0 || eligible > 0) {
-              hasData = true;
-            }
-
-            totalSpend += spend;
-            eligibleSpend += eligible;
-            eligibleBeforeBlocksTotal += eligibleBefore;
-            rewardEarnedDollars += rewardDollars;
-
-            const minRequirement = typeof subDefinition.minimumSpend === 'number' ? subDefinition.minimumSpend : null;
-            if (minRequirement && minRequirement > 0) {
-              minimumTargetSum += minRequirement;
-              const cappedSpend = Math.min(spend, minRequirement);
-              minimumProgressNumerator += cappedSpend;
-              if (spend < minRequirement) {
-                minimumRemainingTotal += minRequirement - spend;
-              }
-            }
-
-            const maxConstraint = typeof subDefinition.maximumSpend === 'number' ? subDefinition.maximumSpend : null;
-            if (maxConstraint && maxConstraint > 0) {
-              hasMaximumConstraint = true;
-              maximumCapSum += maxConstraint;
-              const cappedEligible = Math.min(eligibleBefore, maxConstraint);
-              maximumProgressNumerator += cappedEligible;
-              const remaining = Math.max(0, maxConstraint - eligibleBefore);
-              if (remaining < minHeadroom) {
-                minHeadroom = remaining;
-              }
-              if (eligibleBefore >= maxConstraint) {
-                maxExceeded = true;
-              }
-            }
-          });
-
-          const minimumProgress = minimumTargetSum > 0
-            ? Math.min(100, (minimumProgressNumerator / minimumTargetSum) * 100)
-            : null;
-          const minimumRemaining = minimumTargetSum > 0 ? Math.max(0, minimumRemainingTotal) : null;
-          const minimumMet = minimumRemaining === null || minimumRemaining <= 0.0001;
-
-          const maximumProgress = hasMaximumConstraint && maximumCapSum > 0
-            ? Math.min(100, (maximumProgressNumerator / maximumCapSum) * 100)
-            : null;
-
-          let headroomToMaximum: number | null = null;
-          if (hasMaximumConstraint) {
-            if (minHeadroom === Number.POSITIVE_INFINITY) {
-              headroomToMaximum = Math.max(0, maximumCapSum - maximumProgressNumerator);
-            } else {
-              headroomToMaximum = Math.max(0, minHeadroom);
-            }
+          const subcategoryInsight = createSubcategoryInsight(card, calculation, entry.refs, milesValuation);
+          if (subcategoryInsight) {
+            insights.push(subcategoryInsight);
+            return;
           }
 
-          if (headroomToMaximum !== null && headroomToMaximum <= 0) {
-            maxExceeded = true;
+          if (entry.includeWhole) {
+            insights.push(createWholeCardInsight(card, calculation, milesValuation));
           }
-
-          const cardMinimumMet = calculation
-            ? calculation.minimumMet
-            : (typeof card.minimumSpend !== 'number' || card.minimumSpend <= 0);
-          const cardMinimumProgress = calculation?.minimumProgress ?? null;
-
-          const cardMaximumCap = typeof card.maximumSpend === 'number' && card.maximumSpend > 0
-            ? card.maximumSpend
-            : null;
-          const cardMaximumProgress = calculation?.maximumProgress ?? null;
-          const cardMaximumExceeded = calculation?.maximumExceeded ?? false;
-
-          const shouldAvoid = Boolean(calculation?.shouldStopUsing) || maxExceeded || cardMaximumExceeded;
-          const status: 'use' | 'consider' | 'avoid' = shouldAvoid
-            ? 'avoid'
-            : (!minimumMet || !cardMinimumMet ? 'consider' : 'use');
-
-          const fallbackRate = card.type === 'cashback'
-            ? ((card.earningRate ?? 0) / 100)
-            : ((card.earningRate ?? 0) * milesValuation);
-
-          const rewardRate = totalSpend > 0
-            ? rewardEarnedDollars / totalSpend
-            : fallbackRate;
-
-          insights.push({
-            cardId,
-            cardName: card.name,
-            cardType: card.type,
-            rewardRate,
-            rewardEarnedDollars,
-            totalSpend,
-            eligibleSpend,
-            eligibleSpendBeforeBlocks: eligibleBeforeBlocksTotal,
-            hasData,
-            minimumMet,
-            minimumProgress,
-            minimumTarget: minimumTargetSum > 0 ? minimumTargetSum : null,
-            minimumRemaining,
-            cardMinimumMet,
-            cardMinimumProgress,
-            maximumCap: hasMaximumConstraint ? maximumCapSum : null,
-            maximumProgress,
-            headroomToMaximum,
-            cardMaximumProgress,
-            cardMaximumCap,
-            cardMaximumExceeded,
-            status,
-            shouldAvoid,
-          });
         });
 
         insights.sort((a, b) => {

--- a/apps/web/lib/rewards-engine/types.ts
+++ b/apps/web/lib/rewards-engine/types.ts
@@ -1,0 +1,44 @@
+import type { CreditCard } from '@/lib/storage';
+
+export interface CardRecommendation {
+  cardId: string;
+  cardName: string;
+  reason: string;
+  priority: 'high' | 'medium' | 'low';
+  action: 'use' | 'avoid' | 'consider';
+}
+
+export interface CategoryCardInsight {
+  cardId: string;
+  cardName: string;
+  cardType: CreditCard['type'];
+  rewardRate: number;
+  rewardEarnedDollars: number;
+  totalSpend: number;
+  eligibleSpend: number;
+  eligibleSpendBeforeBlocks: number;
+  hasData: boolean;
+  minimumMet: boolean;
+  minimumProgress?: number | null;
+  minimumTarget?: number | null;
+  minimumRemaining?: number | null;
+  cardMinimumMet: boolean;
+  cardMinimumProgress?: number | null;
+  maximumCap?: number | null;
+  maximumProgress?: number | null;
+  headroomToMaximum?: number | null;
+  cardMaximumProgress?: number | null;
+  cardMaximumCap?: number | null;
+  cardMaximumExceeded: boolean;
+  status: 'use' | 'consider' | 'avoid';
+  shouldAvoid: boolean;
+  notes?: string[];
+}
+
+export interface CategoryRecommendation {
+  groupId: string;
+  groupName: string;
+  groupDescription?: string;
+  latestPeriod?: string;
+  insights: CategoryCardInsight[];
+}

--- a/apps/web/lib/rewards-engine/utils/card-recommendations.test.ts
+++ b/apps/web/lib/rewards-engine/utils/card-recommendations.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CreditCard, RewardCalculation } from '@/lib/storage';
+
+import type { CardRecommendation } from '../types';
+import {
+  EFFECTIVE_RATE_GOOD_THRESHOLD,
+  MINIMUM_PROGRESS_ALERT_THRESHOLD,
+  MINIMUM_PROGRESS_ATTENTION_THRESHOLD,
+  getAlertRecommendations,
+  getCardRecommendations,
+} from './card-recommendations';
+
+const createCard = (overrides: Partial<CreditCard>): CreditCard => ({
+  id: 'card-1',
+  name: 'Rewards Card',
+  issuer: 'Issuer',
+  type: 'cashback',
+  ynabAccountId: 'account-1',
+  featured: true,
+  ...overrides,
+});
+
+const createCalculation = (overrides: Partial<RewardCalculation>): RewardCalculation => ({
+  cardId: 'card-1',
+  ruleId: 'rule-1',
+  period: '2025-01',
+  totalSpend: 0,
+  eligibleSpend: 0,
+  rewardEarned: 0,
+  rewardType: 'cashback',
+  minimumMet: false,
+  maximumExceeded: false,
+  shouldStopUsing: false,
+  ...overrides,
+});
+
+const getActions = (recs: CardRecommendation[]): string[] => recs.map((rec) => `${rec.cardId}:${rec.action}:${rec.priority}`);
+
+describe('getCardRecommendations', () => {
+  it('returns low priority consider recommendation when no activity', () => {
+    const recs = getCardRecommendations([createCard({ id: 'card-1' })], []);
+    expect(recs).toHaveLength(1);
+    expect(recs[0]).toMatchObject({
+      priority: 'low',
+      action: 'consider',
+      reason: 'No activity this period',
+    });
+  });
+
+  it('flags cards that should stop being used', () => {
+    const recs = getCardRecommendations(
+      [createCard({ id: 'card-1' })],
+      [createCalculation({ cardId: 'card-1', shouldStopUsing: true })]
+    );
+    expect(getActions(recs)).toEqual(['card-1:avoid:high']);
+  });
+
+  it('prioritises minimum spend progress', () => {
+    const progress = (MINIMUM_PROGRESS_ATTENTION_THRESHOLD + 100) / 2;
+    const recs = getCardRecommendations(
+      [createCard({ id: 'card-1' })],
+      [createCalculation({ cardId: 'card-1', minimumProgress: progress, eligibleSpend: 1 })]
+    );
+    expect(recs[0]).toMatchObject({ action: 'use', priority: 'medium' });
+  });
+
+  it('recommends cards exceeding effective reward threshold', () => {
+    const rate = EFFECTIVE_RATE_GOOD_THRESHOLD + 0.01;
+    const rewardEarnedDollars = rate * 200;
+    const recs = getCardRecommendations(
+      [createCard({ id: 'card-1' })],
+      [
+        createCalculation({
+          cardId: 'card-1',
+          eligibleSpend: 200,
+          rewardEarnedDollars,
+        }),
+      ]
+    );
+    expect(recs[0]).toMatchObject({ action: 'use', priority: 'medium' });
+    expect(recs[0].reason).toContain('Good reward rate');
+  });
+
+  it('sorts recommendations by priority', () => {
+    const cards = [
+      createCard({ id: 'card-1' }),
+      createCard({ id: 'card-2' }),
+      createCard({ id: 'card-3' }),
+    ];
+    const calculations = [
+      createCalculation({ cardId: 'card-1', shouldStopUsing: true }),
+      createCalculation({ cardId: 'card-2', minimumProgress: MINIMUM_PROGRESS_ATTENTION_THRESHOLD + 1, eligibleSpend: 1 }),
+      createCalculation({ cardId: 'card-3', eligibleSpend: 200, rewardEarnedDollars: (EFFECTIVE_RATE_GOOD_THRESHOLD + 0.01) * 200 }),
+    ];
+
+    const actions = getActions(getCardRecommendations(cards, calculations));
+    expect(actions).toEqual([
+      'card-1:avoid:high',
+      'card-2:use:medium',
+      'card-3:use:medium',
+    ]);
+  });
+});
+
+describe('getAlertRecommendations', () => {
+  it('includes alerts for maximum spend and minimum progress', () => {
+    const alerts = getAlertRecommendations(
+      [createCard({ id: 'card-1' })],
+      [
+        createCalculation({
+          cardId: 'card-1',
+          shouldStopUsing: true,
+          minimumProgress: MINIMUM_PROGRESS_ALERT_THRESHOLD - 10,
+        }),
+      ]
+    );
+
+    expect(alerts).toHaveLength(2);
+    expect(getActions(alerts)).toEqual([
+      'card-1:avoid:high',
+      `card-1:use:medium`,
+    ]);
+  });
+
+  it('ignores minimum progress alerts when above threshold', () => {
+    const alerts = getAlertRecommendations(
+      [createCard({ id: 'card-1' })],
+      [createCalculation({ cardId: 'card-1', minimumProgress: MINIMUM_PROGRESS_ALERT_THRESHOLD })]
+    );
+
+    expect(alerts).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/rewards-engine/utils/card-recommendations.ts
+++ b/apps/web/lib/rewards-engine/utils/card-recommendations.ts
@@ -1,0 +1,129 @@
+import type { CreditCard, RewardCalculation } from '@/lib/storage';
+
+import type { CardRecommendation } from '../types';
+
+const PRIORITY_ORDER: Record<CardRecommendation['priority'], number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+export const MINIMUM_PROGRESS_ATTENTION_THRESHOLD = 50;
+export const MINIMUM_PROGRESS_ALERT_THRESHOLD = 80;
+export const EFFECTIVE_RATE_GOOD_THRESHOLD = 0.02; // 2%
+
+export function getCardRecommendations(
+  cards: CreditCard[],
+  calculations: RewardCalculation[]
+): CardRecommendation[] {
+  const recommendations: CardRecommendation[] = [];
+
+  cards.forEach((card) => {
+    const cardCalculations = calculations.filter((calc) => calc.cardId === card.id);
+
+    if (cardCalculations.length === 0) {
+      recommendations.push({
+        cardId: card.id,
+        cardName: card.name,
+        reason: 'No activity this period',
+        priority: 'low',
+        action: 'consider',
+      });
+      return;
+    }
+
+    if (cardCalculations.some((calc) => calc.shouldStopUsing)) {
+      recommendations.push({
+        cardId: card.id,
+        cardName: card.name,
+        reason: 'Maximum spending limit reached',
+        priority: 'high',
+        action: 'avoid',
+      });
+      return;
+    }
+
+    const needsMoreSpend = cardCalculations.some((calc) => {
+      if (typeof calc.minimumProgress !== 'number') {
+        return false;
+      }
+      return calc.minimumProgress < 100 && calc.minimumProgress > MINIMUM_PROGRESS_ATTENTION_THRESHOLD;
+    });
+
+    if (needsMoreSpend) {
+      recommendations.push({
+        cardId: card.id,
+        cardName: card.name,
+        reason: 'Close to meeting minimum spend requirement',
+        priority: 'medium',
+        action: 'use',
+      });
+      return;
+    }
+
+    const avgRewardRate = averageEffectiveRewardRate(cardCalculations);
+    if (avgRewardRate > EFFECTIVE_RATE_GOOD_THRESHOLD) {
+      recommendations.push({
+        cardId: card.id,
+        cardName: card.name,
+        reason: `Good reward rate (${(avgRewardRate * 100).toFixed(1)}%)`,
+        priority: 'medium',
+        action: 'use',
+      });
+    }
+  });
+
+  return recommendations.sort((a, b) => PRIORITY_ORDER[b.priority] - PRIORITY_ORDER[a.priority]);
+}
+
+export function getAlertRecommendations(
+  cards: CreditCard[],
+  calculations: RewardCalculation[]
+): CardRecommendation[] {
+  const alerts: CardRecommendation[] = [];
+
+  calculations.forEach((calc) => {
+    const card = cards.find((c) => c.id === calc.cardId);
+    if (!card) {
+      return;
+    }
+
+    if (calc.shouldStopUsing) {
+      alerts.push({
+        cardId: card.id,
+        cardName: card.name,
+        reason: 'Stop using - maximum spend reached',
+        priority: 'high',
+        action: 'avoid',
+      });
+    }
+
+    if (typeof calc.minimumProgress === 'number' && calc.minimumProgress < MINIMUM_PROGRESS_ALERT_THRESHOLD) {
+      alerts.push({
+        cardId: card.id,
+        cardName: card.name,
+        reason: `Only ${Math.round(calc.minimumProgress)}% of minimum spend`,
+        priority: 'medium',
+        action: 'use',
+      });
+    }
+  });
+
+  return alerts;
+}
+
+function averageEffectiveRewardRate(calculations: RewardCalculation[]): number {
+  if (calculations.length === 0) {
+    return 0;
+  }
+
+  const totalRate = calculations.reduce((sum, calc) => {
+    if (calc.eligibleSpend <= 0) {
+      return sum;
+    }
+    const rewardDollars = typeof calc.rewardEarnedDollars === 'number' ? calc.rewardEarnedDollars : calc.rewardEarned;
+    return sum + rewardDollars / calc.eligibleSpend;
+  }, 0);
+
+  return totalRate / calculations.length;
+}

--- a/apps/web/lib/rewards-engine/utils/category-insights.test.ts
+++ b/apps/web/lib/rewards-engine/utils/category-insights.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  CardSubcategory,
+  CreditCard,
+  RewardCalculation,
+  SubcategoryReference,
+  ThemeGroup,
+} from '@/lib/storage';
+
+import type { CategoryCardInsight } from '../types';
+import {
+  buildCardEntries,
+  createSubcategoryInsight,
+  createWholeCardInsight,
+} from './category-insights';
+
+const createSubcategory = (overrides: Partial<CardSubcategory>): CardSubcategory => ({
+  id: 'subcategory-1',
+  name: 'Dining',
+  flagColor: 'red',
+  rewardValue: 3,
+  milesBlockSize: null,
+  minimumSpend: null,
+  maximumSpend: null,
+  priority: 1,
+  active: true,
+  excludeFromRewards: false,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const baseCard: CreditCard = {
+  id: 'card-1',
+  name: 'Rewards Card',
+  issuer: 'Issuer',
+  type: 'cashback',
+  ynabAccountId: 'account-1',
+  featured: true,
+};
+
+const milesCard: CreditCard = {
+  ...baseCard,
+  id: 'card-2',
+  name: 'Miles Card',
+  type: 'miles',
+  earningRate: 1.5,
+  minimumSpend: 400,
+  maximumSpend: 600,
+  subcategoriesEnabled: true,
+  subcategories: [
+    createSubcategory({
+      id: 'dining',
+      name: 'Dining',
+      flagColor: 'blue',
+      minimumSpend: 100,
+      maximumSpend: 200,
+    }),
+    createSubcategory({
+      id: 'grocery',
+      name: 'Grocery',
+      flagColor: 'green',
+      maximumSpend: 150,
+    }),
+  ],
+};
+
+describe('buildCardEntries', () => {
+  it('groups card and subcategory references by card id', () => {
+    const group: ThemeGroup = {
+      id: 'group-1',
+      name: 'Dining Focus',
+      description: 'Dining themed cards',
+      colour: 'blue',
+      priority: 1,
+      subcategories: [
+        { cardId: 'card-2', subcategoryId: 'dining' },
+        { cardId: 'card-2', subcategoryId: 'grocery' },
+      ],
+      cards: [{ cardId: 'card-1' }],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    };
+
+    const entries = buildCardEntries(group);
+    expect(entries.size).toBe(2);
+
+    const milesEntry = entries.get('card-2');
+    expect(milesEntry?.refs).toHaveLength(2);
+    expect(milesEntry?.includeWhole).toBe(false);
+
+    const cashEntry = entries.get('card-1');
+    expect(cashEntry?.refs).toHaveLength(0);
+    expect(cashEntry?.includeWhole).toBe(true);
+  });
+});
+
+describe('createWholeCardInsight', () => {
+  it('derives insight metrics from calculation data', () => {
+    const calculation: RewardCalculation = {
+      cardId: baseCard.id,
+      ruleId: 'card-card-1',
+      period: '2025-02',
+      totalSpend: 200,
+      eligibleSpend: 180,
+      rewardEarned: 3.6,
+      rewardEarnedDollars: 3.6,
+      rewardType: 'cashback',
+      minimumMet: false,
+      maximumExceeded: false,
+      shouldStopUsing: false,
+      minimumProgress: 60,
+      maximumProgress: 30,
+    };
+
+    const insight = createWholeCardInsight(
+      { ...baseCard, earningRate: 2, minimumSpend: 300, maximumSpend: 500 },
+      calculation,
+      0.01
+    );
+
+    expect(insight.rewardRate).toBeCloseTo(0.018, 3);
+    expect(insight.minimumMet).toBe(false);
+    expect(insight.headroomToMaximum).toBeCloseTo(320);
+    expect(insight.status).toBe('consider');
+    expect(insight.shouldAvoid).toBe(false);
+    expect(insight.cardMaximumCap).toBe(500);
+  });
+});
+
+describe('createSubcategoryInsight', () => {
+  it('aggregates subcategory breakdowns and reflects constraints', () => {
+    const calculation: RewardCalculation = {
+      cardId: milesCard.id,
+      ruleId: 'card-card-2',
+      period: '2025-03',
+      totalSpend: 350,
+      eligibleSpend: 330,
+      rewardEarned: 0,
+      rewardType: 'miles',
+      minimumMet: true,
+      maximumExceeded: false,
+      shouldStopUsing: false,
+      minimumProgress: 75,
+      maximumProgress: 70,
+      subcategoryBreakdowns: [
+        {
+          subcategoryId: 'dining',
+          name: 'Dining',
+          flagColor: 'blue',
+          totalSpend: 200,
+          eligibleSpend: 200,
+          eligibleSpendBeforeBlocks: 220,
+          rewardEarned: 300,
+          minimumSpendMet: true,
+          maximumSpendExceeded: true,
+        },
+        {
+          subcategoryId: 'grocery',
+          name: 'Grocery',
+          flagColor: 'green',
+          totalSpend: 50,
+          eligibleSpend: 50,
+          eligibleSpendBeforeBlocks: 50,
+          rewardEarned: 75,
+          minimumSpendMet: false,
+          maximumSpendExceeded: false,
+        },
+      ],
+    } as RewardCalculation;
+
+    const refs: SubcategoryReference[] = [
+      { cardId: milesCard.id, subcategoryId: 'dining' },
+      { cardId: milesCard.id, subcategoryId: 'grocery' },
+    ];
+
+    const insight = createSubcategoryInsight(milesCard, calculation, refs, 0.02);
+
+    expect(insight).not.toBeNull();
+    const resolved = insight as CategoryCardInsight;
+    expect(resolved.totalSpend).toBe(250);
+    expect(resolved.rewardEarnedDollars).toBeCloseTo(7.5, 3);
+    expect(resolved.minimumTarget).toBe(100);
+    expect(resolved.minimumMet).toBe(true);
+    expect(resolved.headroomToMaximum).toBe(0);
+    expect(resolved.shouldAvoid).toBe(true);
+    expect(resolved.status).toBe('avoid');
+    expect(resolved.cardMinimumMet).toBe(true);
+    expect(resolved.cardMaximumCap).toBe(600);
+  });
+
+  it('returns null when card subcategories are unavailable', () => {
+    const refs: SubcategoryReference[] = [{ cardId: baseCard.id, subcategoryId: 'dining' }];
+    const insight = createSubcategoryInsight(baseCard, undefined, refs, 0.01);
+    expect(insight).toBeNull();
+  });
+});

--- a/apps/web/lib/rewards-engine/utils/category-insights.ts
+++ b/apps/web/lib/rewards-engine/utils/category-insights.ts
@@ -1,0 +1,333 @@
+import type {
+  CardSubcategory,
+  CreditCard,
+  RewardCalculation,
+  SubcategoryBreakdown,
+  SubcategoryReference,
+  ThemeGroup,
+} from '@/lib/storage';
+
+import type { CategoryCardInsight } from '../types';
+
+export interface GroupCardEntry {
+  refs: SubcategoryReference[];
+  includeWhole: boolean;
+}
+
+export function buildCardEntries(group: ThemeGroup): Map<string, GroupCardEntry> {
+  const entries = new Map<string, GroupCardEntry>();
+
+  (group.subcategories ?? []).forEach((ref) => {
+    if (!ref?.cardId || !ref?.subcategoryId) {
+      return;
+    }
+
+    const existing = entries.get(ref.cardId);
+    if (existing) {
+      existing.refs.push(ref);
+    } else {
+      entries.set(ref.cardId, { refs: [ref], includeWhole: false });
+    }
+  });
+
+  (group.cards ?? []).forEach((ref) => {
+    if (!ref?.cardId) {
+      return;
+    }
+
+    const existing = entries.get(ref.cardId);
+    if (existing) {
+      if (existing.refs.length === 0) {
+        existing.includeWhole = true;
+      }
+    } else {
+      entries.set(ref.cardId, { refs: [], includeWhole: true });
+    }
+  });
+
+  return entries;
+}
+
+export function createWholeCardInsight(
+  card: CreditCard,
+  calculation: RewardCalculation | undefined,
+  milesValuation: number
+): CategoryCardInsight {
+  const totalSpend = calculation?.totalSpend ?? 0;
+  const eligibleSpend = calculation?.eligibleSpend ?? 0;
+  const eligibleBeforeBlocks = calculation?.eligibleSpend ?? eligibleSpend;
+  const rewardEarnedDollars = resolveRewardDollars(calculation, card.type, milesValuation);
+
+  const fallbackRate = computeFallbackRate(card, milesValuation);
+  const rewardRate = totalSpend > 0 ? rewardEarnedDollars / totalSpend : fallbackRate;
+
+  const minimumTarget = getPositiveNumber(card.minimumSpend);
+  const minimumProgress = calculation?.minimumProgress ?? (minimumTarget
+    ? Math.min(100, (totalSpend / minimumTarget) * 100)
+    : null);
+  const minimumRemaining = minimumTarget ? Math.max(0, minimumTarget - totalSpend) : null;
+  const minimumMet = calculation?.minimumMet ?? (minimumTarget ? totalSpend >= minimumTarget : true);
+
+  const maximumCap = getPositiveNumber(card.maximumSpend);
+  const maximumProgress = calculation?.maximumProgress ?? (maximumCap
+    ? Math.min(100, (eligibleBeforeBlocks / maximumCap) * 100)
+    : null);
+  const headroomToMaximum = maximumCap ? Math.max(0, maximumCap - eligibleBeforeBlocks) : null;
+  const maximumExceeded = calculation?.maximumExceeded ?? Boolean(maximumCap && headroomToMaximum !== null && headroomToMaximum <= 0);
+
+  const shouldAvoid = Boolean(calculation?.shouldStopUsing) || maximumExceeded;
+  const status: CategoryCardInsight['status'] = shouldAvoid
+    ? 'avoid'
+    : (minimumMet ? 'use' : 'consider');
+
+  return {
+    cardId: card.id,
+    cardName: card.name,
+    cardType: card.type,
+    rewardRate,
+    rewardEarnedDollars,
+    totalSpend,
+    eligibleSpend,
+    eligibleSpendBeforeBlocks: eligibleBeforeBlocks,
+    hasData: totalSpend > 0 || eligibleSpend > 0,
+    minimumMet,
+    minimumProgress,
+    minimumTarget,
+    minimumRemaining,
+    cardMinimumMet: minimumMet,
+    cardMinimumProgress: minimumProgress,
+    maximumCap,
+    maximumProgress,
+    headroomToMaximum,
+    cardMaximumProgress: maximumProgress,
+    cardMaximumCap: maximumCap,
+    cardMaximumExceeded: maximumExceeded,
+    status,
+    shouldAvoid,
+  };
+}
+
+export function createSubcategoryInsight(
+  card: CreditCard,
+  calculation: RewardCalculation | undefined,
+  refs: SubcategoryReference[],
+  milesValuation: number
+): CategoryCardInsight | null {
+  if (refs.length === 0) {
+    return null;
+  }
+
+  if (!card.subcategoriesEnabled) {
+    return null;
+  }
+
+  const cardSubcategories = Array.isArray(card.subcategories) ? card.subcategories : [];
+  if (cardSubcategories.length === 0) {
+    return null;
+  }
+
+  const subcategoryMap = new Map<string, CardSubcategory>();
+  cardSubcategories.forEach((subcategory) => {
+    if (subcategory && typeof subcategory.id === 'string') {
+      subcategoryMap.set(subcategory.id, subcategory);
+    }
+  });
+
+  const breakdownMap = new Map<string, SubcategoryBreakdown>();
+  calculation?.subcategoryBreakdowns?.forEach((breakdown) => {
+    if (breakdown?.subcategoryId) {
+      breakdownMap.set(breakdown.subcategoryId, breakdown);
+    }
+  });
+
+  let totalSpend = 0;
+  let eligibleSpend = 0;
+  let eligibleBeforeBlocksTotal = 0;
+  let rewardEarnedDollars = 0;
+
+  let minimumTargetSum = 0;
+  let minimumProgressNumerator = 0;
+  let minimumRemainingTotal = 0;
+
+  let hasMaximumConstraint = false;
+  let maximumCapSum = 0;
+  let maximumProgressNumerator = 0;
+  let minHeadroom = Number.POSITIVE_INFINITY;
+  let maxExceeded = false;
+
+  let hasData = false;
+
+  refs.forEach((ref) => {
+    if (!ref?.cardId || !ref?.subcategoryId) {
+      return;
+    }
+
+    const subDefinition = subcategoryMap.get(ref.subcategoryId);
+    if (!subDefinition || subDefinition.active === false || subDefinition.excludeFromRewards) {
+      return;
+    }
+
+    const breakdown = breakdownMap.get(ref.subcategoryId);
+    const spend = breakdown?.totalSpend ?? 0;
+    const eligible = breakdown?.eligibleSpend ?? 0;
+    const eligibleBefore = breakdown?.eligibleSpendBeforeBlocks ?? eligible;
+    const rewardDollars = resolveBreakdownRewardDollars(breakdown, card.type, milesValuation);
+
+    if (spend > 0 || eligible > 0) {
+      hasData = true;
+    }
+
+    totalSpend += spend;
+    eligibleSpend += eligible;
+    eligibleBeforeBlocksTotal += eligibleBefore;
+    rewardEarnedDollars += rewardDollars;
+
+    const minRequirement = getPositiveNumber(subDefinition.minimumSpend);
+    if (minRequirement) {
+      minimumTargetSum += minRequirement;
+      const cappedSpend = Math.min(spend, minRequirement);
+      minimumProgressNumerator += cappedSpend;
+      if (spend < minRequirement) {
+        minimumRemainingTotal += minRequirement - spend;
+      }
+    }
+
+    const maxConstraint = getPositiveNumber(subDefinition.maximumSpend);
+    if (maxConstraint) {
+      hasMaximumConstraint = true;
+      maximumCapSum += maxConstraint;
+      const cappedEligible = Math.min(eligibleBefore, maxConstraint);
+      maximumProgressNumerator += cappedEligible;
+      const remaining = Math.max(0, maxConstraint - eligibleBefore);
+      if (remaining < minHeadroom) {
+        minHeadroom = remaining;
+      }
+      if (eligibleBefore >= maxConstraint) {
+        maxExceeded = true;
+      }
+    }
+  });
+
+  const minimumProgress = minimumTargetSum > 0
+    ? Math.min(100, (minimumProgressNumerator / minimumTargetSum) * 100)
+    : null;
+  const minimumRemaining = minimumTargetSum > 0 ? Math.max(0, minimumRemainingTotal) : null;
+  const minimumMet = minimumRemaining === null || minimumRemaining <= 0.0001;
+
+  const maximumProgress = hasMaximumConstraint && maximumCapSum > 0
+    ? Math.min(100, (maximumProgressNumerator / maximumCapSum) * 100)
+    : null;
+
+  let headroomToMaximum: number | null = null;
+  if (hasMaximumConstraint) {
+    if (minHeadroom === Number.POSITIVE_INFINITY) {
+      headroomToMaximum = Math.max(0, maximumCapSum - maximumProgressNumerator);
+    } else {
+      headroomToMaximum = Math.max(0, minHeadroom);
+    }
+
+    if (headroomToMaximum <= 0) {
+      maxExceeded = true;
+    }
+  }
+
+  const minimumTarget = minimumTargetSum > 0 ? minimumTargetSum : null;
+
+  const cardMinimumMet = calculation
+    ? calculation.minimumMet
+    : (typeof card.minimumSpend !== 'number' || card.minimumSpend <= 0);
+  const cardMinimumProgress = calculation?.minimumProgress ?? null;
+
+  const cardMaximumCap = getPositiveNumber(card.maximumSpend);
+  const cardMaximumProgress = calculation?.maximumProgress ?? null;
+  const cardMaximumExceeded = calculation?.maximumExceeded ?? false;
+
+  const shouldAvoid = Boolean(calculation?.shouldStopUsing) || maxExceeded || cardMaximumExceeded;
+  const fallbackRate = computeFallbackRate(card, milesValuation);
+  const rewardRate = totalSpend > 0 ? rewardEarnedDollars / totalSpend : fallbackRate;
+
+  const status: CategoryCardInsight['status'] = shouldAvoid
+    ? 'avoid'
+    : (!minimumMet || !cardMinimumMet ? 'consider' : 'use');
+
+  return {
+    cardId: card.id,
+    cardName: card.name,
+    cardType: card.type,
+    rewardRate,
+    rewardEarnedDollars,
+    totalSpend,
+    eligibleSpend,
+    eligibleSpendBeforeBlocks: eligibleBeforeBlocksTotal,
+    hasData,
+    minimumMet,
+    minimumProgress,
+    minimumTarget,
+    minimumRemaining,
+    cardMinimumMet,
+    cardMinimumProgress,
+    maximumCap: hasMaximumConstraint ? maximumCapSum : null,
+    maximumProgress,
+    headroomToMaximum,
+    cardMaximumProgress,
+    cardMaximumCap,
+    cardMaximumExceeded,
+    status,
+    shouldAvoid,
+  };
+}
+
+function resolveRewardDollars(
+  calculation: RewardCalculation | undefined,
+  cardType: CreditCard['type'],
+  milesValuation: number
+): number {
+  if (!calculation) {
+    return 0;
+  }
+
+  if (typeof calculation.rewardEarnedDollars === 'number') {
+    return calculation.rewardEarnedDollars;
+  }
+
+  if (cardType === 'cashback') {
+    return calculation.rewardEarned;
+  }
+
+  return calculation.rewardEarned * milesValuation;
+}
+
+function resolveBreakdownRewardDollars(
+  breakdown: SubcategoryBreakdown | undefined,
+  cardType: CreditCard['type'],
+  milesValuation: number
+): number {
+  if (!breakdown) {
+    return 0;
+  }
+
+  if (typeof breakdown.rewardEarnedDollars === 'number') {
+    return breakdown.rewardEarnedDollars;
+  }
+
+  if (cardType === 'cashback') {
+    return breakdown.rewardEarned ?? 0;
+  }
+
+  return (breakdown.rewardEarned ?? 0) * milesValuation;
+}
+
+function computeFallbackRate(card: CreditCard, milesValuation: number): number {
+  if (card.type === 'cashback') {
+    return ((card.earningRate ?? 0) / 100);
+  }
+
+  return (card.earningRate ?? 0) * milesValuation;
+}
+
+function getPositiveNumber(value: number | null | undefined): number | null {
+  if (typeof value === 'number' && value > 0) {
+    return value;
+  }
+  return null;
+}

--- a/apps/web/lib/rewards-engine/utils/periods.test.ts
+++ b/apps/web/lib/rewards-engine/utils/periods.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { CreditCard } from '@/lib/storage';
 
-import { calculateCardPeriod, getRecentCardPeriods, toSimplePeriod } from './periods';
+import { calculateCardPeriod, getRecentCardPeriods, periodOverlapsWindow, toSimplePeriod } from './periods';
 
 const baseCard: CreditCard = {
   id: 'card-1',
@@ -80,5 +80,25 @@ describe('getRecentCardPeriods', () => {
     const periods = getRecentCardPeriods(baseCard, 4);
     expect(periods).toHaveLength(4);
     expect(periods[0].label >= periods[1].label).toBe(true);
+  });
+});
+
+describe('periodOverlapsWindow', () => {
+  it('returns false when period ends before window start', () => {
+    const start = new Date('2025-01-01');
+    const end = new Date('2025-01-31');
+    expect(periodOverlapsWindow(start, end, '2025-02-01')).toBe(false);
+  });
+
+  it('returns false when period starts after window end', () => {
+    const start = new Date('2025-03-01');
+    const end = new Date('2025-03-31');
+    expect(periodOverlapsWindow(start, end, undefined, '2025-02-28')).toBe(false);
+  });
+
+  it('returns true when period overlaps the window bounds', () => {
+    const start = new Date('2025-04-01');
+    const end = new Date('2025-04-30');
+    expect(periodOverlapsWindow(start, end, '2025-04-15', '2025-05-15')).toBe(true);
   });
 });

--- a/apps/web/lib/rewards-engine/utils/periods.ts
+++ b/apps/web/lib/rewards-engine/utils/periods.ts
@@ -88,3 +88,23 @@ export function toSimplePeriod(period: CardPeriod, useStartDateLabel: boolean = 
     label: useStartDateLabel ? formatLocalDate(period.startDate) : period.label,
   };
 }
+
+export function periodOverlapsWindow(
+  periodStart: Date,
+  periodEnd: Date,
+  windowStart?: string,
+  windowEnd?: string
+): boolean {
+  const startBoundary = windowStart ? new Date(windowStart) : undefined;
+  const endBoundary = windowEnd ? new Date(windowEnd) : undefined;
+
+  if (startBoundary && periodEnd < startBoundary) {
+    return false;
+  }
+
+  if (endBoundary && periodStart > endBoundary) {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/web/lib/rewards-engine/utils/recommendation-helpers.test.ts
+++ b/apps/web/lib/rewards-engine/utils/recommendation-helpers.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RewardCalculation } from '@/lib/storage';
+
+import type { CategoryCardInsight } from '../types';
+import {
+  STATUS_PRIORITY,
+  mapLatestSubcategoryCalculations,
+  resolveLatestPeriod,
+  sortCategoryInsights,
+} from './recommendation-helpers';
+
+const createCalculation = (overrides: Partial<RewardCalculation>): RewardCalculation => ({
+  cardId: overrides.cardId ?? 'card-1',
+  ruleId: overrides.ruleId ?? 'rule-1',
+  period: overrides.period ?? '2025-01',
+  totalSpend: overrides.totalSpend ?? 0,
+  eligibleSpend: overrides.eligibleSpend ?? 0,
+  rewardEarned: overrides.rewardEarned ?? 0,
+  rewardType: overrides.rewardType ?? 'cashback',
+  minimumMet: overrides.minimumMet ?? false,
+  maximumExceeded: overrides.maximumExceeded ?? false,
+  shouldStopUsing: overrides.shouldStopUsing ?? false,
+  subcategoryBreakdowns: overrides.subcategoryBreakdowns,
+  rewardEarnedDollars: overrides.rewardEarnedDollars,
+  minimumProgress: overrides.minimumProgress,
+  maximumProgress: overrides.maximumProgress,
+});
+
+const createInsight = (overrides: Partial<CategoryCardInsight>): CategoryCardInsight => ({
+  cardId: 'card-1',
+  cardName: 'Card',
+  cardType: 'cashback',
+  rewardRate: 0,
+  rewardEarnedDollars: 0,
+  totalSpend: 0,
+  eligibleSpend: 0,
+  eligibleSpendBeforeBlocks: 0,
+  hasData: true,
+  minimumMet: true,
+  cardMinimumMet: true,
+  cardMaximumExceeded: false,
+  status: 'use',
+  shouldAvoid: false,
+  ...overrides,
+});
+
+describe('resolveLatestPeriod', () => {
+  it('identifies the most recent period', () => {
+    const calculations = [
+      createCalculation({ period: '2025-01' }),
+      createCalculation({ period: '2025-03' }),
+      createCalculation({ period: '2025-02' }),
+    ];
+
+    expect(resolveLatestPeriod(calculations)).toBe('2025-03');
+  });
+
+  it('returns undefined when no calculations provided', () => {
+    expect(resolveLatestPeriod([])).toBeUndefined();
+  });
+});
+
+describe('mapLatestSubcategoryCalculations', () => {
+  it('captures only latest period calculations with subcategory breakdowns', () => {
+    const calculations = [
+      createCalculation({
+        cardId: 'card-1',
+        period: '2025-03',
+        subcategoryBreakdowns: [{
+          subcategoryId: 'sub-1',
+          name: 'Dining',
+          flagColor: 'blue',
+          totalSpend: 100,
+          eligibleSpend: 100,
+          rewardEarned: 2,
+          minimumSpendMet: true,
+          maximumSpendExceeded: false,
+        }],
+      }),
+      createCalculation({
+        cardId: 'card-1',
+        period: '2025-02',
+        subcategoryBreakdowns: [{
+          subcategoryId: 'sub-1',
+          name: 'Dining',
+          flagColor: 'blue',
+          totalSpend: 90,
+          eligibleSpend: 90,
+          rewardEarned: 1.8,
+          minimumSpendMet: true,
+          maximumSpendExceeded: false,
+        }],
+      }),
+      createCalculation({
+        cardId: 'card-2',
+        period: '2025-03',
+        subcategoryBreakdowns: [],
+      }),
+      createCalculation({
+        cardId: 'card-3',
+        period: '2025-03',
+      }),
+    ];
+
+    const { latestPeriod, byCard } = mapLatestSubcategoryCalculations(calculations);
+
+    expect(latestPeriod).toBe('2025-03');
+    expect(byCard.size).toBe(1);
+    expect(byCard.get('card-1')?.period).toBe('2025-03');
+  });
+});
+
+describe('sortCategoryInsights', () => {
+  it('orders insights by status priority, reward rate, then reward dollars', () => {
+    const insights = [
+      createInsight({ cardId: 'card-1', status: 'consider', rewardRate: 0.03, rewardEarnedDollars: 10 }),
+      createInsight({ cardId: 'card-2', status: 'use', rewardRate: 0.01, rewardEarnedDollars: 5 }),
+      createInsight({ cardId: 'card-3', status: 'use', rewardRate: 0.02, rewardEarnedDollars: 8 }),
+      createInsight({ cardId: 'card-4', status: 'avoid', rewardRate: 0.05, rewardEarnedDollars: 15 }),
+      createInsight({ cardId: 'card-5', status: 'use', rewardRate: 0.02, rewardEarnedDollars: 9 }),
+    ];
+
+    const sorted = sortCategoryInsights(insights);
+    const ids = sorted.map((insight) => insight.cardId);
+
+    expect(ids).toEqual(['card-5', 'card-3', 'card-2', 'card-1', 'card-4']);
+    expect(STATUS_PRIORITY[sorted[0].status]).toBeGreaterThanOrEqual(STATUS_PRIORITY[sorted[1].status]);
+  });
+});

--- a/apps/web/lib/rewards-engine/utils/recommendation-helpers.ts
+++ b/apps/web/lib/rewards-engine/utils/recommendation-helpers.ts
@@ -1,0 +1,58 @@
+import type { RewardCalculation } from '@/lib/storage';
+
+import type { CategoryCardInsight } from '../types';
+
+export const STATUS_PRIORITY: Record<CategoryCardInsight['status'], number> = {
+  use: 3,
+  consider: 2,
+  avoid: 1,
+};
+
+export function resolveLatestPeriod(calculations: RewardCalculation[]): string | undefined {
+  return calculations.reduce<string | undefined>((latest, calc) => {
+    if (!latest) {
+      return calc.period;
+    }
+    return calc.period > latest ? calc.period : latest;
+  }, undefined);
+}
+
+export function mapLatestSubcategoryCalculations(calculations: RewardCalculation[]): {
+  latestPeriod?: string;
+  byCard: Map<string, RewardCalculation>;
+} {
+  const latestPeriod = resolveLatestPeriod(calculations);
+  const relevant = latestPeriod
+    ? calculations.filter((calc) => calc.period === latestPeriod)
+    : calculations;
+
+  const byCard = new Map<string, RewardCalculation>();
+
+  relevant.forEach((calc) => {
+    if (!calc.subcategoryBreakdowns || calc.subcategoryBreakdowns.length === 0) {
+      return;
+    }
+
+    const existing = byCard.get(calc.cardId);
+    if (!existing || calc.period >= existing.period) {
+      byCard.set(calc.cardId, calc);
+    }
+  });
+
+  return { latestPeriod, byCard };
+}
+
+export function sortCategoryInsights(insights: CategoryCardInsight[]): CategoryCardInsight[] {
+  return [...insights].sort((a, b) => {
+    const statusDiff = STATUS_PRIORITY[b.status] - STATUS_PRIORITY[a.status];
+    if (statusDiff !== 0) {
+      return statusDiff;
+    }
+
+    if (b.rewardRate !== a.rewardRate) {
+      return b.rewardRate - a.rewardRate;
+    }
+
+    return b.rewardEarnedDollars - a.rewardEarnedDollars;
+  });
+}

--- a/apps/web/lib/rewards-engine/utils/reward-calculation.test.ts
+++ b/apps/web/lib/rewards-engine/utils/reward-calculation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CreditCard } from '@/lib/storage';
+
+import type { SimplifiedCalculation, SubcategoryCalculation } from '../simple-calculator';
+import { createRewardCalculationFromSimple } from './reward-calculation';
+
+const baseCard: CreditCard = {
+  id: 'card-1',
+  name: 'Card',
+  issuer: 'Issuer',
+  type: 'cashback',
+  ynabAccountId: 'account-1',
+  featured: true,
+};
+
+const createSubcategory = (overrides: Partial<SubcategoryCalculation>): SubcategoryCalculation => ({
+  id: overrides.id ?? 'sub-1',
+  name: overrides.name ?? 'Dining',
+  flagColor: overrides.flagColor ?? 'blue',
+  totalSpend: overrides.totalSpend ?? 120,
+  eligibleSpendBeforeBlocks: overrides.eligibleSpendBeforeBlocks ?? 120,
+  eligibleSpend: overrides.eligibleSpend ?? 120,
+  rewardRate: overrides.rewardRate ?? 3,
+  rewardEarned: overrides.rewardEarned ?? 3.6,
+  rewardEarnedDollars: overrides.rewardEarnedDollars ?? 3.6,
+  minimumSpend: overrides.minimumSpend,
+  minimumSpendMet: overrides.minimumSpendMet ?? true,
+  maximumSpend: overrides.maximumSpend,
+  maximumSpendExceeded: overrides.maximumSpendExceeded ?? false,
+  blockSize: overrides.blockSize ?? null,
+  blocksEarned: overrides.blocksEarned,
+  active: overrides.active ?? true,
+  excluded: overrides.excluded ?? false,
+});
+
+describe('createRewardCalculationFromSimple', () => {
+  it('maps simplified calculation fields to reward calculation output', () => {
+    const simpleCalc: SimplifiedCalculation = {
+      cardId: baseCard.id,
+      period: '2025-02',
+      totalSpend: 500,
+      eligibleSpend: 400,
+      eligibleSpendBeforeBlocks: 450,
+      rewardEarned: 12,
+      rewardEarnedDollars: 12,
+      rewardType: 'cashback',
+      minimumSpend: 300,
+      minimumSpendMet: true,
+      minimumSpendProgress: 100,
+      maximumSpend: 800,
+      maximumSpendExceeded: false,
+      maximumSpendProgress: 50,
+      subcategoryBreakdowns: [
+        createSubcategory({ id: 'sub-1', name: 'Dining', flagColor: 'blue' }),
+        createSubcategory({ id: 'sub-2', name: 'Groceries', flagColor: 'green', totalSpend: 80 }),
+      ],
+    };
+
+    const rewardCalc = createRewardCalculationFromSimple(baseCard, simpleCalc);
+
+    expect(rewardCalc.cardId).toBe(baseCard.id);
+    expect(rewardCalc.ruleId).toBe('card-card-1');
+    expect(rewardCalc.period).toBe('2025-02');
+    expect(rewardCalc.totalSpend).toBe(500);
+    expect(rewardCalc.eligibleSpend).toBe(400);
+    expect(rewardCalc.rewardEarned).toBe(12);
+    expect(rewardCalc.rewardEarnedDollars).toBe(12);
+    expect(rewardCalc.minimumProgress).toBe(100);
+    expect(rewardCalc.maximumProgress).toBe(50);
+    expect(rewardCalc.minimumMet).toBe(true);
+    expect(rewardCalc.maximumExceeded).toBe(false);
+    expect(rewardCalc.shouldStopUsing).toBe(false);
+    expect(rewardCalc.subcategoryBreakdowns).toHaveLength(2);
+    expect(rewardCalc.subcategoryBreakdowns?.[0]).toMatchObject({
+      subcategoryId: 'sub-1',
+      name: 'Dining',
+      flagColor: 'blue',
+      totalSpend: 120,
+      eligibleSpend: 120,
+      rewardEarned: 3.6,
+      minimumSpendMet: true,
+      maximumSpendExceeded: false,
+    });
+  });
+
+  it('allows overriding the generated rule id', () => {
+    const simpleCalc: SimplifiedCalculation = {
+      cardId: baseCard.id,
+      period: '2025-03',
+      totalSpend: 100,
+      eligibleSpend: 100,
+      rewardEarned: 2,
+      rewardEarnedDollars: 2,
+      rewardType: 'cashback',
+      minimumSpendMet: false,
+      maximumSpendExceeded: false,
+    };
+
+    const rewardCalc = createRewardCalculationFromSimple(baseCard, simpleCalc, 'custom-rule');
+    expect(rewardCalc.ruleId).toBe('custom-rule');
+  });
+});

--- a/apps/web/lib/rewards-engine/utils/reward-calculation.ts
+++ b/apps/web/lib/rewards-engine/utils/reward-calculation.ts
@@ -1,0 +1,41 @@
+import type { RewardCalculation, CreditCard, SubcategoryBreakdown } from '@/lib/storage';
+
+import type { SimplifiedCalculation, SubcategoryCalculation } from '../simple-calculator';
+
+function mapSubcategoryBreakdown(subcategory: SubcategoryCalculation): SubcategoryBreakdown {
+  return {
+    subcategoryId: subcategory.id,
+    name: subcategory.name,
+    flagColor: subcategory.flagColor,
+    totalSpend: subcategory.totalSpend,
+    eligibleSpend: subcategory.eligibleSpend,
+    eligibleSpendBeforeBlocks: subcategory.eligibleSpendBeforeBlocks,
+    rewardEarned: subcategory.rewardEarned,
+    rewardEarnedDollars: subcategory.rewardEarnedDollars,
+    minimumSpendMet: subcategory.minimumSpendMet,
+    maximumSpendExceeded: subcategory.maximumSpendExceeded,
+  };
+}
+
+export function createRewardCalculationFromSimple(
+  card: CreditCard,
+  calculation: SimplifiedCalculation,
+  overrideRuleId?: string
+): RewardCalculation {
+  return {
+    cardId: card.id,
+    ruleId: overrideRuleId ?? `card-${card.id}`,
+    period: calculation.period,
+    totalSpend: calculation.totalSpend,
+    eligibleSpend: calculation.eligibleSpend,
+    rewardEarned: calculation.rewardEarned,
+    rewardEarnedDollars: calculation.rewardEarnedDollars,
+    rewardType: calculation.rewardType,
+    minimumProgress: calculation.minimumSpendProgress,
+    maximumProgress: calculation.maximumSpendProgress,
+    minimumMet: calculation.minimumSpendMet,
+    maximumExceeded: calculation.maximumSpendExceeded,
+    shouldStopUsing: calculation.maximumSpendExceeded,
+    subcategoryBreakdowns: calculation.subcategoryBreakdowns?.map(mapSubcategoryBreakdown),
+  };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,8 +28,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.1.5"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "workspaces": [
     "apps/*",
-    "packages/*",
-    "docs"
+    "packages/*"
   ],
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
-      zod:
-        specifier: ^4.1.5
-        version: 4.1.5
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.16
@@ -2924,9 +2921,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  zod@4.1.5:
-    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
 snapshots:
 
@@ -5908,5 +5902,3 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
-
-  zod@4.1.5: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
-  - 'docs'
 


### PR DESCRIPTION
## Summary
- extract shared rewards engine helpers and recommendation utilities
- split the dashboard page into focused components and simplify rendering
- centralise storage hook hydration and tidy unused dependencies/workspaces

## Testing
- pnpm lint
- pnpm run typecheck
- pnpm test