### PR TITLE
feat: add optional cloud sync via cloudflare kv

### DIFF
--- a/apps/web/app/api/cloud-sync/route.ts
+++ b/apps/web/app/api/cloud-sync/route.ts
@@ -1,0 +1,175 @@
+import { NextResponse } from 'next/server';
+
+const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
+const CLOUDFLARE_KV_NAMESPACE_ID = process.env.CLOUDFLARE_KV_NAMESPACE_ID;
+const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+
+if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_KV_NAMESPACE_ID || !CLOUDFLARE_API_TOKEN) {
+  console.warn('Cloud sync API environment variables are missing. Cloud sync will be disabled.');
+}
+
+const VERSION = 1;
+
+interface CloudflareError {
+  success: boolean;
+  errors: Array<{ code: number; message: string }>;
+}
+
+class CloudflareKVError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function requestCloudflareKV(key: string, init: RequestInit): Promise<Response> {
+  if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_KV_NAMESPACE_ID || !CLOUDFLARE_API_TOKEN) {
+    return new Response('Cloud sync not configured', { status: 501 });
+  }
+
+  const endpoint = new URL(
+    `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces/${CLOUDFLARE_KV_NAMESPACE_ID}/values/${encodeURIComponent(
+      key
+    )}`
+  );
+
+  const response = await fetch(endpoint, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`,
+      'Content-Type': 'text/plain',
+      ...(init.headers || {}),
+    },
+  });
+
+  if (!response.ok && process.env.NODE_ENV !== 'production') {
+    console.error('Cloud sync KV request failed', {
+      method: init.method || 'GET',
+      status: response.status,
+      statusText: response.statusText,
+      endpoint: endpoint.href,
+    });
+  }
+
+  return response;
+}
+
+async function storeValue(key: string, value: string): Promise<void> {
+  const response = await requestCloudflareKV(key, {
+    method: 'PUT',
+    body: value,
+  });
+
+  if (!response.ok) {
+    const error = (await response.json().catch(() => null)) as CloudflareError | null;
+    const message = error?.errors?.[0]?.message || (await response.text().catch(() => '')) || 'Failed to store cloud sync data';
+    throw new CloudflareKVError(`Cloudflare (${response.status}): ${message}`, response.status || 502);
+  }
+}
+
+async function retrieveValue(key: string): Promise<string | null> {
+  const response = await requestCloudflareKV(key, {
+    method: 'GET',
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new CloudflareKVError(`Cloudflare (${response.status}): ${body || 'Failed to retrieve cloud sync data'}`, response.status || 502);
+  }
+
+  return response.text();
+}
+
+async function deleteValue(key: string): Promise<void> {
+  const response = await requestCloudflareKV(key, {
+    method: 'DELETE',
+  });
+
+  if (response.status === 404) {
+    return;
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new CloudflareKVError(`Cloudflare (${response.status}): ${body || 'Failed to delete cloud sync data'}`, response.status || 502);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { keyId, ciphertext, iv } = body ?? {};
+
+    if (typeof keyId !== 'string' || typeof ciphertext !== 'string' || typeof iv !== 'string') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const updatedAt = new Date().toISOString();
+    const payload = JSON.stringify({ ciphertext, iv, version: VERSION, updatedAt });
+    await storeValue(keyId, payload);
+
+    return NextResponse.json({ updatedAt, version: VERSION });
+  } catch (error) {
+    if (error instanceof CloudflareKVError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const keyId = searchParams.get('key');
+
+  if (!keyId) {
+    return NextResponse.json({ error: 'Missing key parameter' }, { status: 400 });
+  }
+
+  try {
+    const stored = await retrieveValue(keyId);
+    if (!stored) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const parsed = JSON.parse(stored) as { ciphertext: string; iv: string; version?: number; updatedAt?: string };
+    return NextResponse.json({
+      ciphertext: parsed.ciphertext,
+      iv: parsed.iv,
+      version: parsed.version ?? VERSION,
+      updatedAt: parsed.updatedAt ?? new Date().toISOString(),
+    });
+  } catch (error) {
+    if (error instanceof CloudflareKVError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const keyId = searchParams.get('key');
+
+  if (!keyId) {
+    return NextResponse.json({ error: 'Missing key parameter' }, { status: 400 });
+  }
+
+  try {
+    await deleteValue(keyId);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof CloudflareKVError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -411,7 +411,9 @@ export default function SettingsPage() {
     try {
       return JSON.parse(exportSettings());
     } catch (error) {
-      throw new Error('Failed to prepare settings for cloud sync');
+      const baseMessage = 'Failed to prepare settings for cloud sync';
+      const details = error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`${baseMessage}: ${details}`);
     }
   }
 

--- a/apps/web/hooks/useLocalStorage.ts
+++ b/apps/web/hooks/useLocalStorage.ts
@@ -18,7 +18,13 @@ const EMPTY_CALCULATION_LIST: RewardCalculation[] = [];
 const EMPTY_SELECTED_BUDGET: { id?: string; name?: string } = {};
 const EMPTY_THEME_GROUP_LIST: ThemeGroup[] = [];
 const EMPTY_HIDDEN_CARD_LIST: HiddenCard[] = [];
-const DEFAULT_SETTINGS: AppSettings = { theme: 'light', currency: 'USD', dashboardViewMode: 'summary' };
+const DEFAULT_SETTINGS: AppSettings = {
+  theme: 'light',
+  currency: 'USD',
+  dashboardViewMode: 'summary',
+  cloudSyncKeyId: undefined,
+  cloudSyncLastSyncedAt: undefined,
+};
 
 function useHasHydrated() {
   const [hasHydrated, setHasHydrated] = useState(false);

--- a/apps/web/lib/cloud-sync/api.ts
+++ b/apps/web/lib/cloud-sync/api.ts
@@ -1,0 +1,57 @@
+export interface EncryptedSyncPayload {
+  keyId: string;
+  ciphertext: string;
+  iv: string;
+}
+
+export interface CloudSyncMetadata {
+  updatedAt: string;
+  version: number;
+}
+
+export interface CloudSyncResponse extends CloudSyncMetadata {
+  ciphertext: string;
+  iv: string;
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (response.ok) {
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return (await response.json()) as T;
+  }
+
+  const message = await response.text();
+  throw new Error(message || 'Cloud sync request failed');
+}
+
+export async function uploadEncryptedSettings(payload: EncryptedSyncPayload): Promise<CloudSyncMetadata> {
+  const response = await fetch('/api/cloud-sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse<CloudSyncMetadata>(response);
+}
+
+export async function fetchEncryptedSettings(keyId: string): Promise<CloudSyncResponse | null> {
+  const response = await fetch(`/api/cloud-sync?key=${encodeURIComponent(keyId)}`, {
+    method: 'GET',
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  return handleResponse<CloudSyncResponse>(response);
+}
+
+export async function deleteEncryptedSettings(keyId: string): Promise<void> {
+  const response = await fetch(`/api/cloud-sync?key=${encodeURIComponent(keyId)}`, {
+    method: 'DELETE',
+  });
+
+  await handleResponse<undefined>(response);
+}

--- a/apps/web/lib/cloud-sync/encryption.test.ts
+++ b/apps/web/lib/cloud-sync/encryption.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { webcrypto } from 'node:crypto';
+
+import {
+  computeKeyId,
+  decryptJson,
+  encryptJson,
+  isValidMnemonic,
+  normaliseMnemonic,
+} from '@/lib/cloud-sync';
+
+beforeAll(() => {
+  if (!globalThis.crypto?.subtle) {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  }
+
+  if (typeof globalThis.atob !== 'function') {
+    Object.defineProperty(globalThis, 'atob', {
+      value: (input: string) => Buffer.from(input, 'base64').toString('binary'),
+      configurable: true,
+    });
+  }
+
+  if (typeof globalThis.btoa !== 'function') {
+    Object.defineProperty(globalThis, 'btoa', {
+      value: (input: string) => Buffer.from(input, 'binary').toString('base64'),
+      configurable: true,
+    });
+  }
+});
+
+describe('cloud sync encryption helpers', () => {
+  const mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+  it('normalises phrases and derives stable key ids', async () => {
+    const messy = '  Abandon   ABANDON   abandon\n    Abandon   abandon  abandon   abandon   abandon   abandon   Abandon   abandon   about ';
+
+    const normalised = normaliseMnemonic(messy);
+    expect(normalised).toBe(mnemonic);
+    expect(isValidMnemonic(normalised)).toBe(true);
+
+    const [idA, idB] = await Promise.all([
+      computeKeyId(mnemonic),
+      computeKeyId(messy),
+    ]);
+
+    expect(idA).toBe(idB);
+  });
+
+  it('encrypts and decrypts payloads symmetrically', async () => {
+    const payload = {
+      cards: [{ id: 'test-card', name: 'Test Card' }],
+      settings: { currency: 'USD', milesValuation: 0.0125 },
+    };
+
+    const encrypted = await encryptJson(mnemonic, payload);
+    expect(encrypted.ciphertext).toBeTypeOf('string');
+    expect(encrypted.iv).toBeTypeOf('string');
+
+    const decrypted = await decryptJson<typeof payload>(mnemonic, encrypted.ciphertext, encrypted.iv);
+    expect(decrypted).toEqual(payload);
+  });
+
+  it('rejects decryption with the wrong mnemonic', async () => {
+    const payload = { foo: 'bar' };
+    const encrypted = await encryptJson(mnemonic, payload);
+
+    await expect(
+      decryptJson('legal winner thank year wave sausage worth useful legal winner thank yellow', encrypted.ciphertext, encrypted.iv)
+    ).rejects.toThrow();
+  });
+});

--- a/apps/web/lib/cloud-sync/encryption.ts
+++ b/apps/web/lib/cloud-sync/encryption.ts
@@ -1,0 +1,142 @@
+import { normaliseMnemonic } from './mnemonic';
+
+const SALT = 'ynab-rewards-cloud-sync-v1';
+const PBKDF2_ITERATIONS = 210_000;
+const PBKDF2_HASH = 'SHA-256';
+const AES_ALGO = 'AES-GCM';
+const AES_KEY_LENGTH = 256;
+const IV_LENGTH_BYTES = 12;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+type BufferLike = Uint8Array & { toString(encoding: string): string };
+type BufferConstructorLike = {
+  from(data: Uint8Array | string, encoding?: string): BufferLike;
+};
+
+function ensureCrypto(): Crypto {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto API not available in this environment');
+  }
+  return globalThis.crypto;
+}
+
+function getNodeBuffer(): BufferConstructorLike | undefined {
+  const candidate = (globalThis as Record<string, unknown>).Buffer as BufferConstructorLike | undefined;
+  return typeof candidate === 'function' ? candidate : undefined;
+}
+
+function toBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  if (typeof globalThis.btoa === 'function') {
+    const base64 = globalThis.btoa(binary);
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  }
+
+  const nodeBuffer = getNodeBuffer();
+  if (nodeBuffer) {
+    return nodeBuffer.from(bytes)
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+  }
+
+  throw new Error('No base64 encoder available');
+}
+
+function fromBase64Url(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '==='.slice((base64.length + 3) % 4);
+
+  if (typeof globalThis.atob === 'function') {
+    const binary = globalThis.atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  const nodeBuffer = getNodeBuffer();
+  if (nodeBuffer) {
+    return nodeBuffer.from(padded, 'base64');
+  }
+
+  throw new Error('No base64 decoder available');
+}
+
+async function deriveKey(mnemonic: string): Promise<CryptoKey> {
+  const crypto = ensureCrypto();
+  const normalised = normaliseMnemonic(mnemonic);
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    textEncoder.encode(normalised),
+    'PBKDF2',
+    false,
+    ['deriveKey', 'deriveBits']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: textEncoder.encode(SALT),
+      iterations: PBKDF2_ITERATIONS,
+      hash: PBKDF2_HASH,
+    },
+    keyMaterial,
+    { name: AES_ALGO, length: AES_KEY_LENGTH },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function computeKeyId(mnemonic: string): Promise<string> {
+  const crypto = ensureCrypto();
+  const normalised = normaliseMnemonic(mnemonic);
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    textEncoder.encode(`ynab-rewards-key:${normalised}`)
+  );
+  return toBase64Url(digest);
+}
+
+export async function encryptJson<T>(mnemonic: string, data: T): Promise<{ ciphertext: string; iv: string }> {
+  const crypto = ensureCrypto();
+  const key = await deriveKey(mnemonic);
+  const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH_BYTES));
+  const payload = textEncoder.encode(JSON.stringify(data));
+  const encrypted = await crypto.subtle.encrypt({ name: AES_ALGO, iv }, key, payload);
+
+  return {
+    ciphertext: toBase64Url(encrypted),
+    iv: toBase64Url(iv.buffer),
+  };
+}
+
+export async function decryptJson<T>(mnemonic: string, ciphertext: string, iv: string): Promise<T> {
+  const crypto = ensureCrypto();
+  const key = await deriveKey(mnemonic);
+  const payload = await crypto.subtle.decrypt(
+    { name: AES_ALGO, iv: fromBase64Url(iv) },
+    key,
+    fromBase64Url(ciphertext)
+  );
+
+  const decoded = textDecoder.decode(payload);
+  return JSON.parse(decoded) as T;
+}
+
+export function getBase64UrlFromBuffer(buffer: ArrayBuffer): string {
+  return toBase64Url(buffer);
+}
+
+export function getBufferFromBase64Url(value: string): Uint8Array {
+  return fromBase64Url(value);
+}

--- a/apps/web/lib/cloud-sync/encryption.ts
+++ b/apps/web/lib/cloud-sync/encryption.ts
@@ -23,16 +23,17 @@ function ensureCrypto(): Crypto {
 }
 
 function getNodeBuffer(): BufferConstructorLike | undefined {
-  const candidate = (globalThis as Record<string, unknown>).Buffer as BufferConstructorLike | undefined;
-  return typeof candidate === 'function' ? candidate : undefined;
+  if (!('Buffer' in globalThis)) {
+    return undefined;
+  }
+
+  const candidate = (globalThis as typeof globalThis & { Buffer?: unknown }).Buffer;
+  return typeof candidate === 'function' ? (candidate as BufferConstructorLike) : undefined;
 }
 
 function toBase64Url(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
-  let binary = '';
-  bytes.forEach((byte) => {
-    binary += String.fromCharCode(byte);
-  });
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
 
   if (typeof globalThis.btoa === 'function') {
     const base64 = globalThis.btoa(binary);

--- a/apps/web/lib/cloud-sync/index.ts
+++ b/apps/web/lib/cloud-sync/index.ts
@@ -1,0 +1,3 @@
+export * from './mnemonic';
+export * from './encryption';
+export * from './api';

--- a/apps/web/lib/cloud-sync/mnemonic.ts
+++ b/apps/web/lib/cloud-sync/mnemonic.ts
@@ -1,0 +1,41 @@
+import { entropyToMnemonic, validateMnemonic } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+const DEFAULT_STRENGTH = 128; // 12 words
+
+function getRandomBytes(size: number): Uint8Array {
+  const randomBytes = new Uint8Array(size);
+  if (typeof globalThis.crypto?.getRandomValues !== 'function') {
+    throw new Error('Secure random generator unavailable');
+  }
+  globalThis.crypto.getRandomValues(randomBytes);
+  return randomBytes;
+}
+
+export function normaliseMnemonic(input: string): string {
+  return input
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.toLowerCase())
+    .join(' ');
+}
+
+export function createMnemonic(strength: number = DEFAULT_STRENGTH): string {
+  const entropyBytes = strength / 8;
+  if (!Number.isInteger(entropyBytes)) {
+    throw new Error('Mnemonic strength must be a multiple of 32');
+  }
+  const entropy = getRandomBytes(entropyBytes);
+  return entropyToMnemonic(entropy, wordlist);
+}
+
+export function isValidMnemonic(phrase: string): boolean {
+  try {
+    return validateMnemonic(normaliseMnemonic(phrase), wordlist);
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('Failed to validate mnemonic:', error);
+    }
+    return false;
+  }
+}

--- a/apps/web/lib/storage/types.ts
+++ b/apps/web/lib/storage/types.ts
@@ -144,6 +144,8 @@ export interface AppSettings {
   currency?: string;
   milesValuation?: number;
   dashboardViewMode?: DashboardViewMode;
+  cloudSyncKeyId?: string;
+  cloudSyncLastSyncedAt?: string;
 }
 
 export interface StorageData {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@scure/bip39": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@scure/bip39':
+        specifier: ^2.0.0
+        version: 2.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -421,6 +424,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/hashes@2.0.0':
+    resolution: {integrity: sha512-h8VUBlE8R42+XIDO229cgisD287im3kdY6nbNZJFjc6ZvKIXPYXe6Vc/t+kyjFdMFyt5JpapzTsEg8n63w5/lw==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -977,6 +984,12 @@ packages:
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip39@2.0.0':
+    resolution: {integrity: sha512-F2Tza4KyTSFO/13JymY6a6UHfSLzx0YGbkQGz7wjGx2BYJLyG/qXELKnFFsDfeIK+WfV2v2+5XOQftvL4d8RBA==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -3126,6 +3139,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.5':
     optional: true
 
+  '@noble/hashes@2.0.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3643,6 +3658,13 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@scure/base@2.0.0': {}
+
+  '@scure/bip39@2.0.0':
+    dependencies:
+      '@noble/hashes': 2.0.0
+      '@scure/base': 2.0.0
 
   '@standard-schema/spec@1.0.0': {}
 


### PR DESCRIPTION
## Summary
- add Cloudflare KV backed API route for encrypted settings sync
- add client-side mnemonic/encryption utilities and settings UI
- cover crypto helpers with tests and add @scure/bip39 dependency

## Testing
- pnpm lint
- pnpm -C apps/web typecheck
- pnpm -C apps/web test