### PR TITLE
feat: add dedicated transactions view

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -46,6 +46,7 @@ import {
   CloudOff,
   KeyRound,
 } from 'lucide-react';
+import { DashboardQuickStats } from '@/components/dashboard/DashboardQuickStats';
 
 interface YnabBudget {
   id: string;
@@ -556,6 +557,11 @@ export default function SettingsPage() {
   return (
     <div className="max-w-6xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold">Settings</h1>
+
+      <DashboardQuickStats
+        selectedBudget={selectedBudget}
+        trackedAccountCount={trackedAccountIds.length}
+      />
 
       {/* YNAB Connection */}
       <Card id="settings-budget">

--- a/apps/web/app/transactions/page.tsx
+++ b/apps/web/app/transactions/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  useYnabPAT,
+  useCreditCards,
+  useSelectedBudget,
+  useTrackedAccountIds
+} from "@/hooks/useLocalStorage";
+import { useTrackedTransactions } from "@/hooks/useTrackedTransactions";
+import { DashboardLanding } from "@/components/dashboard/DashboardLanding";
+import { SetupProgressAlert } from "@/components/dashboard/SetupProgressAlert";
+import { RecentTransactionsTable } from "@/components/dashboard/RecentTransactionsTable";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card";
+
+const TRANSACTION_LOOKBACK_DAYS = 60;
+const EXTENDED_TRANSACTIONS_LIMIT = 100;
+
+interface SetupStatus {
+  pat: boolean;
+  budget: boolean;
+  accounts: boolean;
+  cards: boolean;
+}
+
+export default function TransactionsPage() {
+  const { pat } = useYnabPAT();
+  const { cards } = useCreditCards();
+  const { selectedBudget } = useSelectedBudget();
+  const { trackedAccountIds } = useTrackedAccountIds();
+
+  const setupStatus: SetupStatus = useMemo(
+    () => ({
+      pat: Boolean(pat),
+      budget: Boolean(selectedBudget.id),
+      accounts: trackedAccountIds.length > 0,
+      cards: cards.length > 0
+    }),
+    [pat, selectedBudget.id, trackedAccountIds.length, cards.length]
+  );
+
+  const setupProgress = useMemo(
+    () => Object.values(setupStatus).filter(Boolean).length,
+    [setupStatus]
+  );
+
+  const setupPercentage = useMemo(
+    () => (setupProgress / 4) * 100,
+    [setupProgress]
+  );
+
+  const featuredCards = useMemo(
+    () => cards.filter((card) => card.featured ?? true),
+    [cards]
+  );
+
+  const { recentTransactions, accountsMap, loading, error } = useTrackedTransactions({
+    pat,
+    selectedBudgetId: selectedBudget.id,
+    trackedAccountIds,
+    featuredCards,
+    lookbackDays: TRANSACTION_LOOKBACK_DAYS,
+    recentLimit: EXTENDED_TRANSACTIONS_LIMIT
+  });
+
+  if (!setupStatus.pat) {
+    return <DashboardLanding />;
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Transactions</h1>
+        <p className="text-muted-foreground">
+          Review up to the last {EXTENDED_TRANSACTIONS_LIMIT} transactions from your tracked accounts.
+        </p>
+      </div>
+
+      {setupProgress < 4 && (
+        <SetupProgressAlert
+          setupStatus={setupStatus}
+          setupProgress={setupProgress}
+          setupPercentage={setupPercentage}
+        />
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Transactions</CardTitle>
+          <CardDescription>
+            Showing activity from the past {TRANSACTION_LOOKBACK_DAYS} days across your tracked accounts.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RecentTransactionsTable
+            loading={loading}
+            error={error}
+            transactions={recentTransactions}
+            accountsMap={accountsMap}
+            lookbackDays={TRANSACTION_LOOKBACK_DAYS}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/Navigation.tsx
+++ b/apps/web/components/Navigation.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Home, Settings, CreditCard, SlidersHorizontal, Sparkles } from 'lucide-react';
+import { Home, Settings, CreditCard, SlidersHorizontal, Sparkles, ReceiptText } from 'lucide-react';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { cn } from '@/lib/utils';
 
@@ -14,6 +14,7 @@ export function Navigation() {
     { href: '/', label: 'Dashboard', icon: Home },
     { href: '/recommendations', label: 'Recommendations', icon: Sparkles },
     { href: '/rules', label: 'Rules', icon: SlidersHorizontal },
+    { href: '/transactions', label: 'Transactions', icon: ReceiptText },
   ];
 
   const isSettings = pathname.startsWith('/settings');

--- a/apps/web/components/dashboard/DashboardCardOverview.tsx
+++ b/apps/web/components/dashboard/DashboardCardOverview.tsx
@@ -1,9 +1,34 @@
 "use client";
 
 import Link from "next/link";
-import type { MouseEvent, ReactNode } from "react";
-import { useMemo, useCallback } from "react";
-import { CreditCard as CreditCardIcon, Percent, Settings2, TrendingUp } from "lucide-react";
+import type { CSSProperties, MouseEvent, ReactNode } from "react";
+import { useMemo, useCallback, useEffect, useRef, useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  CreditCard as CreditCardIcon,
+  GripVertical,
+  Percent,
+  Settings2,
+  TrendingUp,
+} from "lucide-react";
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  useSortable,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import type {
   CreditCard,
@@ -36,6 +61,10 @@ interface DashboardCardOverviewProps {
   onUnhideAll(): void;
   pat: string;
   prefetchedTransactions: Transaction[];
+  cashbackCollapsed: boolean;
+  milesCollapsed: boolean;
+  onToggleGroup(category: 'cashback' | 'miles'): void;
+  onReorderCards(category: 'cashback' | 'miles', orderedIds: string[]): void;
 }
 
 function createSettingsClickHandler(cardId: string) {
@@ -58,6 +87,10 @@ export function DashboardCardOverview({
   onUnhideAll,
   pat,
   prefetchedTransactions,
+  cashbackCollapsed,
+  milesCollapsed,
+  onToggleGroup,
+  onReorderCards,
 }: DashboardCardOverviewProps) {
   const hiddenCount = hiddenCards.length;
   const hasVisibleCards = visibleFeaturedCards.length > 0;
@@ -118,6 +151,7 @@ export function DashboardCardOverview({
       <>
         {cashbackCards.length > 0 && (
           <CardGroup
+            category="cashback"
             title="Cashback Cards"
             icon={<Percent className="h-5 w-5 text-green-600" aria-hidden="true" />}
             cards={cashbackCards}
@@ -125,10 +159,14 @@ export function DashboardCardOverview({
             pat={pat}
             prefetchedTransactions={prefetchedTransactions}
             onHideCard={onHideCard}
+            isCollapsed={cashbackCollapsed}
+            onToggleCollapse={() => onToggleGroup('cashback')}
+            onReorderCards={(orderedIds) => onReorderCards('cashback', orderedIds)}
           />
         )}
         {milesCards.length > 0 && (
           <CardGroup
+            category="miles"
             title="Miles Cards"
             icon={<TrendingUp className="h-5 w-5 text-blue-600" aria-hidden="true" />}
             cards={milesCards}
@@ -136,11 +174,29 @@ export function DashboardCardOverview({
             pat={pat}
             prefetchedTransactions={prefetchedTransactions}
             onHideCard={onHideCard}
+            isCollapsed={milesCollapsed}
+            onToggleCollapse={() => onToggleGroup('miles')}
+            onReorderCards={(orderedIds) => onReorderCards('miles', orderedIds)}
           />
         )}
       </>
     );
-  }, [cards.length, hasVisibleCards, cashbackCards, viewMode, pat, prefetchedTransactions, onHideCard, milesCards, hiddenCount, handleShowAll]);
+  }, [
+    cards.length,
+    hasVisibleCards,
+    cashbackCards,
+    viewMode,
+    pat,
+    prefetchedTransactions,
+    onHideCard,
+    milesCards,
+    hiddenCount,
+    handleShowAll,
+    cashbackCollapsed,
+    milesCollapsed,
+    onToggleGroup,
+    onReorderCards,
+  ]);
 
   return (
     <div className="space-y-8 mb-8">
@@ -197,6 +253,7 @@ export function DashboardCardOverview({
 }
 
 interface CardGroupProps {
+  category: 'cashback' | 'miles';
   title: string;
   icon: ReactNode;
   cards: CreditCard[];
@@ -204,82 +261,243 @@ interface CardGroupProps {
   pat: string;
   prefetchedTransactions: Transaction[];
   onHideCard(cardId: string, hiddenUntil: string): void;
+  isCollapsed: boolean;
+  onToggleCollapse(): void;
+  onReorderCards(orderedIds: string[]): void;
 }
 
-function CardGroup({ title, icon, cards, viewMode, pat, prefetchedTransactions, onHideCard }: CardGroupProps) {
+function CardGroup({
+  category,
+  title,
+  icon,
+  cards,
+  viewMode,
+  pat,
+  prefetchedTransactions,
+  onHideCard,
+  isCollapsed,
+  onToggleCollapse,
+  onReorderCards,
+}: CardGroupProps) {
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const items = useMemo(() => cards.map((card) => card.id), [cards]);
+  const contentId = `${category}-card-group`;
+  const ChevronIcon = isCollapsed ? ChevronRight : ChevronDown;
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+
+      const activeId = String(active.id);
+      const overId = String(over.id);
+      const oldIndex = items.indexOf(activeId);
+      const newIndex = items.indexOf(overId);
+
+      if (oldIndex === -1 || newIndex === -1) {
+        return;
+      }
+
+      const reordered = arrayMove(items, oldIndex, newIndex);
+      onReorderCards(reordered);
+    },
+    [items, onReorderCards]
+  );
+
   return (
-    <div>
-      <div className="flex items-center gap-2 mb-4">
-        {icon}
-        <h2 className="text-xl font-semibold">{title}</h2>
+    <section className="space-y-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          aria-expanded={!isCollapsed}
+          aria-controls={contentId}
+          className="flex items-center gap-2 text-left text-xl font-semibold transition-colors hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 rounded-md px-1 py-1"
+        >
+          <ChevronIcon className="h-5 w-5" aria-hidden="true" />
+          {icon}
+          <span>{title}</span>
+        </button>
         <Badge variant="secondary">{cards.length}</Badge>
       </div>
-      <div
-        className={cn(
-          "grid gap-4",
-          viewMode === "detailed"
-            ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
-            : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-        )}
+
+      {!isCollapsed && cards.length > 0 && (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={({ active }) => setActiveDragId(String(active.id))}
+          onDragCancel={() => setActiveDragId(null)}
+          onDragEnd={(event) => {
+            handleDragEnd(event);
+            setActiveDragId(null);
+          }}
+        >
+          <SortableContext items={items} strategy={rectSortingStrategy}>
+            <div
+              id={contentId}
+              className={cn(
+                "grid gap-4",
+                viewMode === "detailed"
+                  ? "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+                  : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+              )}
+            >
+              {cards.map((card) => (
+                <SortableDashboardCard
+                  key={card.id}
+                  card={card}
+                  viewMode={viewMode}
+                  pat={pat}
+                  prefetchedTransactions={prefetchedTransactions}
+                  onHideCard={onHideCard}
+                  isSorting={Boolean(activeDragId)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      {isCollapsed && <div id={contentId} className="hidden" aria-hidden="true" />}
+    </section>
+  );
+}
+
+interface SortableDashboardCardProps {
+  card: CreditCard;
+  viewMode: DashboardViewMode;
+  pat: string;
+  prefetchedTransactions: Transaction[];
+  onHideCard(cardId: string, hiddenUntil: string): void;
+  isSorting: boolean;
+}
+
+function SortableDashboardCard({ card, viewMode, pat, prefetchedTransactions, onHideCard, isSorting }: SortableDashboardCardProps) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
+    id: card.id,
+  });
+
+  const suppressClickRef = useRef(false);
+
+  useEffect(() => {
+    if (isSorting) {
+      suppressClickRef.current = true;
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      suppressClickRef.current = false;
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 150);
+
+    return () => window.clearTimeout(timeout);
+  }, [isSorting]);
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  if (isDragging) {
+    style.zIndex = 50;
+  }
+
+  const accentClasses = "border border-border/70 dark:border-border/50 hover:border-primary/40";
+
+  return (
+    <div ref={setNodeRef} style={style} className="focus-visible:outline-none">
+      <Link
+        href={`/cards/${card.id}`}
+        className="block group"
+        draggable={false}
+        onClickCapture={(event) => {
+          if (suppressClickRef.current) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
       >
-        {cards.map((card) => {
-          const accentClasses = "border border-border/70 dark:border-border/50 hover:border-primary/40";
+        <Card
+          className={cn(
+            "relative overflow-hidden flex flex-col h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-lg",
+            "bg-card",
+            accentClasses,
+            isDragging ? "ring-2 ring-primary/60 shadow-lg" : undefined
+          )}
+        >
+          <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={createSettingsClickHandler(card.id)}
+              aria-label="Go to card settings"
+            >
+              <Settings2 className="h-4 w-4" />
+            </Button>
+          </div>
 
-          return (
-            <Link key={card.id} href={`/cards/${card.id}`} className="block group">
-              <Card
-                className={cn(
-                  "relative overflow-hidden flex flex-col h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-lg",
-                  "bg-card",
-                  accentClasses
-                )}
-              >
-                <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={createSettingsClickHandler(card.id)}
-                    aria-label="Go to card settings"
-                  >
-                    <Settings2 className="h-4 w-4" />
-                  </Button>
-                </div>
+          <div className="absolute bottom-3 right-3">
+            <Button
+              ref={setActivatorNodeRef}
+              type="button"
+              variant="secondary"
+              size="icon"
+              className="h-9 w-9 rounded-full bg-background/90 backdrop-blur px-0 cursor-grab active:cursor-grabbing shadow-sm border border-border/60 hover:bg-background"
+              aria-label={`Reorder ${card.name}`}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
 
-                <CardHeader className="pb-3">
-                  <CardTitle
-                    title={card.name}
-                    className={cn(
-                      viewMode === "detailed" ? "text-lg" : "text-[0.95rem] sm:text-base",
-                      "pr-12 truncate"
-                    )}
-                  >
-                    {card.name}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="flex-1 flex flex-col">
-                  {viewMode === "detailed" ? (
-                    <CardSpendingSummary
-                      card={card}
-                      pat={pat}
-                      prefetchedTransactions={prefetchedTransactions}
-                      onHideCard={onHideCard}
-                      showHideOption
-                    />
-                  ) : (
-                    <CardSummaryCompact
-                      card={card}
-                      pat={pat}
-                      prefetchedTransactions={prefetchedTransactions}
-                      onHideCard={onHideCard}
-                    />
-                  )}
-                </CardContent>
-              </Card>
-            </Link>
-          );
-        })}
-      </div>
+          <CardHeader className="pb-3">
+            <CardTitle
+              title={card.name}
+              className={cn(
+                viewMode === "detailed" ? "text-lg" : "text-[0.95rem] sm:text-base",
+                "pr-12 truncate"
+              )}
+            >
+              {card.name}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex-1 flex flex-col">
+            {viewMode === "detailed" ? (
+              <CardSpendingSummary
+                card={card}
+                pat={pat}
+                prefetchedTransactions={prefetchedTransactions}
+                onHideCard={onHideCard}
+                showHideOption
+              />
+            ) : (
+              <CardSummaryCompact
+                card={card}
+                pat={pat}
+                prefetchedTransactions={prefetchedTransactions}
+                onHideCard={onHideCard}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </Link>
     </div>
   );
 }

--- a/apps/web/hooks/useLocalStorage.ts
+++ b/apps/web/hooks/useLocalStorage.ts
@@ -24,6 +24,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   dashboardViewMode: 'summary',
   cloudSyncKeyId: undefined,
   cloudSyncLastSyncedAt: undefined,
+  cardOrdering: {},
+  collapsedCardGroups: {},
 };
 
 function useHasHydrated() {

--- a/apps/web/hooks/useTrackedTransactions.ts
+++ b/apps/web/hooks/useTrackedTransactions.ts
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { YnabClient } from "@/lib/ynab-client";
+import { SimpleRewardsCalculator } from "@/lib/rewards-engine";
+import type { CreditCard } from "@/lib/storage";
+import type { Transaction } from "@/types/transaction";
+
+interface UseTrackedTransactionsArgs {
+  pat?: string;
+  selectedBudgetId?: string;
+  trackedAccountIds: string[];
+  featuredCards: CreditCard[];
+  lookbackDays: number;
+  recentLimit?: number;
+}
+
+interface UseTrackedTransactionsResult {
+  recentTransactions: Transaction[];
+  allTransactions: Transaction[];
+  accountsMap: Map<string, string>;
+  loading: boolean;
+  error: string;
+  refresh(): void;
+}
+
+/**
+ * Fetches YNAB transactions for the selected budget and provides filtered subsets
+ * tailored for tracked accounts and lookback windows.
+ *
+ * Transactions are retrieved once per budget/lookback window combination and cached
+ * locally via `allTransactions`. `recentTransactions` is derived client-side so that
+ * changes to the account filters, lookback window, or list size do not trigger
+ * redundant network requests. Consumers can call `refresh()` to manually refetch,
+ * and the hook aborts any in-flight request during unmount to avoid memory leaks.
+ */
+export function useTrackedTransactions({
+  pat,
+  selectedBudgetId,
+  trackedAccountIds,
+  featuredCards,
+  lookbackDays,
+  recentLimit,
+}: UseTrackedTransactionsArgs): UseTrackedTransactionsResult {
+  const [recentTransactions, setRecentTransactions] = useState<Transaction[]>([]);
+  const [allTransactions, setAllTransactions] = useState<Transaction[]>([]);
+  const [accountsMap, setAccountsMap] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const abortRef = useRef<AbortController | null>(null);
+  const lastFetchKeyRef = useRef("");
+
+  const earliestTrackedWindow = useMemo(() => {
+    if (featuredCards.length === 0) {
+      const fallback = new Date();
+      fallback.setDate(fallback.getDate() - lookbackDays);
+      return fallback.toISOString().split("T")[0];
+    }
+
+    const earliestMillis = featuredCards
+      .map((card) => SimpleRewardsCalculator.calculatePeriod(card))
+      .map((period) => new Date(period.start).getTime())
+      .reduce((min, current) => Math.min(min, current), Number.POSITIVE_INFINITY);
+
+    return new Date(earliestMillis).toISOString().split("T")[0];
+  }, [featuredCards, lookbackDays]);
+
+  const loadTransactions = useCallback(async () => {
+    if (!pat || !selectedBudgetId) {
+      setRecentTransactions([]);
+      setAllTransactions([]);
+      setAccountsMap(new Map());
+      setError("");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const client = new YnabClient(pat);
+
+      const accounts = await client.getAccounts<{ id: string; name: string }>(selectedBudgetId, {
+        signal: controller.signal,
+      });
+      const accountNameMap = new Map<string, string>();
+      accounts.forEach((account) => {
+        accountNameMap.set(account.id, account.name);
+      });
+      setAccountsMap(accountNameMap);
+
+      const transactions = await client.getTransactions(selectedBudgetId, {
+        since_date: earliestTrackedWindow,
+        signal: controller.signal,
+      });
+      setAllTransactions(transactions);
+    } catch (err) {
+      if (!(err instanceof Error) || err.name !== "AbortError") {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(`Failed to load transactions: ${message}`);
+        lastFetchKeyRef.current = "";
+      }
+    } finally {
+      if (abortRef.current === controller) {
+        setLoading(false);
+        abortRef.current = null;
+      }
+    }
+  }, [pat, selectedBudgetId, earliestTrackedWindow]);
+
+  useEffect(() => {
+    if (!pat || !selectedBudgetId) {
+      lastFetchKeyRef.current = "";
+      setRecentTransactions([]);
+      setAllTransactions([]);
+      setAccountsMap(new Map());
+      return;
+    }
+
+    const fetchKey = [pat, selectedBudgetId, earliestTrackedWindow].join("::");
+
+    if (lastFetchKeyRef.current === fetchKey) {
+      return;
+    }
+
+    lastFetchKeyRef.current = fetchKey;
+    loadTransactions();
+  }, [pat, selectedBudgetId, earliestTrackedWindow, loadTransactions]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pat || !selectedBudgetId) {
+      setRecentTransactions([]);
+      return;
+    }
+
+    const sortedTransactions = [...allTransactions].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+
+    const cutoff = lookbackDays > 0 ? (() => {
+      const date = new Date();
+      date.setDate(date.getDate() - lookbackDays);
+      return date;
+    })() : null;
+
+    let filtered = sortedTransactions;
+
+    if (trackedAccountIds.length > 0) {
+      filtered = filtered.filter((transaction) => trackedAccountIds.includes(transaction.account_id));
+    }
+
+    if (cutoff) {
+      filtered = filtered.filter((transaction) => new Date(transaction.date) >= cutoff);
+    }
+
+    if (typeof recentLimit === "number" && recentLimit > 0) {
+      filtered = filtered.slice(0, recentLimit);
+    }
+
+    setRecentTransactions(filtered);
+  }, [
+    allTransactions,
+    pat,
+    selectedBudgetId,
+    trackedAccountIds,
+    lookbackDays,
+    recentLimit,
+  ]);
+
+  const refresh = useCallback(() => {
+    lastFetchKeyRef.current = "";
+    loadTransactions();
+  }, [loadTransactions]);
+
+  return {
+    recentTransactions,
+    allTransactions,
+    accountsMap,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/apps/web/lib/storage/normalisers.ts
+++ b/apps/web/lib/storage/normalisers.ts
@@ -383,6 +383,8 @@ export function createDefaultStorage(): StorageData {
       theme: 'light',
       currency: 'USD',
       dashboardViewMode: 'summary',
+      cardOrdering: {},
+      collapsedCardGroups: {},
     },
   };
 }

--- a/apps/web/lib/storage/types.ts
+++ b/apps/web/lib/storage/types.ts
@@ -146,6 +146,8 @@ export interface AppSettings {
   dashboardViewMode?: DashboardViewMode;
   cloudSyncKeyId?: string;
   cloudSyncLastSyncedAt?: string;
+  cardOrdering?: Partial<Record<'cashback' | 'miles', string[]>>;
+  collapsedCardGroups?: Partial<Record<'cashback' | 'miles', boolean>>;
 }
 
 export interface StorageData {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -151,6 +160,28 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -2938,6 +2969,31 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@emnapi/core@1.5.0':
     dependencies:


### PR DESCRIPTION
## Summary
- create reusable tracked transactions hook and refactor dashboard to consume it
- add dedicated /transactions page and move quick stats to settings
- adjust navigation to surface transactions as last tab

## Testing
- pnpm --filter ./apps/web typecheck
- pnpm --filter ./apps/web test
