### PR TITLE
fix: guard empty cloud sync uploads

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -24,6 +24,14 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Switch } from '@/components/ui/switch';
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -188,6 +196,8 @@ export default function SettingsPage() {
   const [cloudSyncAction, setCloudSyncAction] = useState<'idle' | 'generate' | 'upload' | 'download' | 'delete' | 'sync'>('idle');
   const [showAdvancedSync, setShowAdvancedSync] = useState(false);
   const [showGenerateDialog, setShowGenerateDialog] = useState(false);
+  const [justToggledRemember, setJustToggledRemember] = useState(false);
+  const [showEmptySyncWarningDialog, setShowEmptySyncWarningDialog] = useState(false);
   const hasInitializedPhraseRef = useRef(false);
   const orphanedMessageTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -710,6 +720,7 @@ export default function SettingsPage() {
       });
       setCloudSyncPhrase(normalised);
       setCloudSyncMessage('Sync code saved to this device.');
+      setJustToggledRemember(true);
     } else {
       // User wants to stop remembering
       updateSettings({
@@ -721,6 +732,29 @@ export default function SettingsPage() {
   }
 
   async function handleSyncNow() {
+    setCloudSyncError('');
+    setCloudSyncMessage('');
+
+    // Check if settings are essentially empty
+    const exportedSettings = parseExportedSettings();
+    const hasNoCards = !exportedSettings || typeof exportedSettings !== 'object' ||
+                      !('cards' in exportedSettings) ||
+                      (Array.isArray(exportedSettings.cards) && exportedSettings.cards.length === 0);
+    const hasNoRules = !exportedSettings || typeof exportedSettings !== 'object' ||
+                      !('rules' in exportedSettings) ||
+                      (Array.isArray(exportedSettings.rules) && exportedSettings.rules.length === 0);
+
+    // If settings are empty and there's a previous cloud backup, warn user
+    if (hasNoCards && hasNoRules && settings.cloudSyncLastSyncedAt) {
+      setShowEmptySyncWarningDialog(true);
+      return;
+    }
+
+    // Proceed with upload
+    await performSyncUpload();
+  }
+
+  async function performSyncUpload() {
     setCloudSyncError('');
     setCloudSyncMessage('');
     setCloudSyncAction('sync');
@@ -741,6 +775,16 @@ export default function SettingsPage() {
     } finally {
       setCloudSyncAction('idle');
     }
+  }
+
+  async function handleDownloadInsteadOfUpload() {
+    setShowEmptySyncWarningDialog(false);
+    await handleCloudDownload();
+  }
+
+  async function handleUploadAnywayDespiteEmpty() {
+    setShowEmptySyncWarningDialog(false);
+    await performSyncUpload();
   }
 
   // Fix #7: Less aggressive - keep sync history (keyId, lastSyncedAt)
@@ -1088,7 +1132,7 @@ export default function SettingsPage() {
         <CardContent>
           <div className="space-y-4">
             {/* Simple Mode: Code is remembered */}
-            {isCodeRemembered && !showAdvancedSync ? (
+            {isCodeRemembered && !showAdvancedSync && !justToggledRemember ? (
               <>
                 <div className="flex items-center justify-between rounded-lg border bg-muted/30 p-4">
                   <div className="flex items-center gap-3">
@@ -1252,7 +1296,10 @@ export default function SettingsPage() {
                       type="button"
                       variant="outline"
                       size="sm"
-                      onClick={() => setShowAdvancedSync(false)}
+                      onClick={() => {
+                        setShowAdvancedSync(false);
+                        setJustToggledRemember(false);
+                      }}
                     >
                       <ChevronUp className="mr-2 h-3 w-3" aria-hidden="true" />
                       Show simple mode
@@ -1366,6 +1413,36 @@ export default function SettingsPage() {
         onConfirm={confirmClearOrphanedCards}
         onCancel={() => setShowClearOrphanedDialog(false)}
       />
+
+      {/* Empty Sync Warning Dialog - Custom 3-button variant */}
+      <Dialog open={showEmptySyncWarningDialog} onOpenChange={(open) => !open && setShowEmptySyncWarningDialog(false)}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Info className="h-5 w-5 text-primary" aria-hidden="true" />
+              Your local settings are empty
+            </DialogTitle>
+            <DialogDescription className="pt-2">
+              You have no cards or rules configured locally, but there's a cloud backup from{' '}
+              {cloudSyncLastSynced}. Uploading now would overwrite your cloud backup with empty settings.
+              <br /><br />
+              Would you like to download your settings from the cloud instead?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-0 flex-col sm:flex-row">
+            <Button variant="outline" onClick={() => setShowEmptySyncWarningDialog(false)}>
+              Cancel
+            </Button>
+            <Button variant="outline" onClick={handleUploadAnywayDespiteEmpty}>
+              Upload Anyway
+            </Button>
+            <Button variant="default" onClick={handleDownloadInsteadOfUpload}>
+              <CloudDownload className="mr-2 h-4 w-4" aria-hidden="true" />
+              Download Instead
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       </div>
 
     </div>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -602,6 +602,12 @@ export default function SettingsPage() {
       return;
     }
 
+    // Check for empty upload attempt
+    if (shouldWarnAboutEmptyUpload()) {
+      setShowEmptySyncWarningDialog(true);
+      return;
+    }
+
     setCloudSyncError('');
     setCloudSyncMessage('');
     setCloudSyncAction('upload');
@@ -732,11 +738,8 @@ export default function SettingsPage() {
     }
   }
 
-  async function handleSyncNow() {
-    setCloudSyncError('');
-    setCloudSyncMessage('');
-
-    // Check if settings are essentially empty
+  // Helper to check if uploading empty settings would overwrite cloud backup
+  function shouldWarnAboutEmptyUpload(): boolean {
     const exportedSettings = parseExportedSettings();
     const hasNoCards = !exportedSettings || typeof exportedSettings !== 'object' ||
                       !('cards' in exportedSettings) ||
@@ -745,15 +748,21 @@ export default function SettingsPage() {
                       !('rules' in exportedSettings) ||
                       (Array.isArray(exportedSettings.rules) && exportedSettings.rules.length === 0);
 
-    // If settings are empty and there's likely a cloud backup, warn user
     // Detect cloud backup via:
     // 1. cloudSyncKeyId exists (uploaded before on this or another device)
     // 2. OR user has a sync code but no keyId yet (likely entered code from another device)
     const hasSyncKeyId = Boolean(settings.cloudSyncKeyId);
-    const hasCodeButNoKeyId = (storedMnemonic || cloudSyncPhrase.trim()) && !settings.cloudSyncKeyId;
+    const hasCodeButNoKeyId = Boolean(storedMnemonic || cloudSyncPhrase.trim()) && !settings.cloudSyncKeyId;
     const likelyHasCloudBackup = hasSyncKeyId || hasCodeButNoKeyId;
 
-    if (hasNoCards && hasNoRules && likelyHasCloudBackup) {
+    return hasNoCards && hasNoRules && likelyHasCloudBackup;
+  }
+
+  async function handleSyncNow() {
+    setCloudSyncError('');
+    setCloudSyncMessage('');
+
+    if (shouldWarnAboutEmptyUpload()) {
       setShowEmptySyncWarningDialog(true);
       return;
     }
@@ -1431,8 +1440,8 @@ export default function SettingsPage() {
               Your local settings are empty
             </DialogTitle>
             <DialogDescription className="pt-2">
-              You have no cards or rules configured locally, but there's a cloud backup from{' '}
-              {cloudSyncLastSynced}. Uploading now would overwrite your cloud backup with empty settings.
+              You have no cards or rules configured locally, but there's likely a cloud backup{' '}
+              {cloudSyncLastSynced ? `from ${cloudSyncLastSynced}` : 'from another device'}. Uploading now would overwrite your cloud backup with empty settings.
               <br /><br />
               Would you like to download your settings from the cloud instead?
             </DialogDescription>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -721,6 +721,7 @@ export default function SettingsPage() {
       setCloudSyncPhrase(normalised);
       setCloudSyncMessage('Sync code saved to this device.');
       setJustToggledRemember(true);
+      setShowAdvancedSync(true); // Ensure user can access "Show simple mode" button
     } else {
       // User wants to stop remembering
       updateSettings({
@@ -744,8 +745,15 @@ export default function SettingsPage() {
                       !('rules' in exportedSettings) ||
                       (Array.isArray(exportedSettings.rules) && exportedSettings.rules.length === 0);
 
-    // If settings are empty and there's a previous cloud backup, warn user
-    if (hasNoCards && hasNoRules && settings.cloudSyncLastSyncedAt) {
+    // If settings are empty and there's likely a cloud backup, warn user
+    // Detect cloud backup via:
+    // 1. cloudSyncKeyId exists (uploaded before on this or another device)
+    // 2. OR user has a sync code but no keyId yet (likely entered code from another device)
+    const hasSyncKeyId = Boolean(settings.cloudSyncKeyId);
+    const hasCodeButNoKeyId = (storedMnemonic || cloudSyncPhrase.trim()) && !settings.cloudSyncKeyId;
+    const likelyHasCloudBackup = hasSyncKeyId || hasCodeButNoKeyId;
+
+    if (hasNoCards && hasNoRules && likelyHasCloudBackup) {
       setShowEmptySyncWarningDialog(true);
       return;
     }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -740,22 +740,27 @@ export default function SettingsPage() {
 
   // Helper to check if uploading empty settings would overwrite cloud backup
   function shouldWarnAboutEmptyUpload(): boolean {
-    const exportedSettings = parseExportedSettings();
-    const hasNoCards = !exportedSettings || typeof exportedSettings !== 'object' ||
-                      !('cards' in exportedSettings) ||
-                      (Array.isArray(exportedSettings.cards) && exportedSettings.cards.length === 0);
-    const hasNoRules = !exportedSettings || typeof exportedSettings !== 'object' ||
-                      !('rules' in exportedSettings) ||
-                      (Array.isArray(exportedSettings.rules) && exportedSettings.rules.length === 0);
+    try {
+      const exportedSettings = parseExportedSettings() as {
+        cards?: unknown;
+        rules?: unknown;
+      };
 
-    // Detect cloud backup via:
-    // 1. cloudSyncKeyId exists (uploaded before on this or another device)
-    // 2. OR user has a sync code but no keyId yet (likely entered code from another device)
-    const hasSyncKeyId = Boolean(settings.cloudSyncKeyId);
-    const hasCodeButNoKeyId = Boolean(storedMnemonic || cloudSyncPhrase.trim()) && !settings.cloudSyncKeyId;
-    const likelyHasCloudBackup = hasSyncKeyId || hasCodeButNoKeyId;
+      const hasNoCards = !Array.isArray(exportedSettings?.cards) || exportedSettings.cards.length === 0;
+      const hasNoRules = !Array.isArray(exportedSettings?.rules) || exportedSettings.rules.length === 0;
 
-    return hasNoCards && hasNoRules && likelyHasCloudBackup;
+      // Detect cloud backup via:
+      // 1. cloudSyncKeyId exists (uploaded before on this or another device)
+      // 2. OR user has a sync code but no keyId yet (likely entered code from another device)
+      const hasSyncKeyId = Boolean(settings.cloudSyncKeyId);
+      const hasCodeButNoKeyId = Boolean((storedMnemonic || cloudSyncPhrase).trim()) && !settings.cloudSyncKeyId;
+      const likelyHasCloudBackup = hasSyncKeyId || hasCodeButNoKeyId;
+
+      return hasNoCards && hasNoRules && likelyHasCloudBackup;
+    } catch (error) {
+      // If we can't parse settings, assume they're not empty to avoid blocking uploads
+      return false;
+    }
   }
 
   async function handleSyncNow() {

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -232,6 +232,7 @@ export default function SettingsPage() {
   const cloudSyncLastSynced = settings.cloudSyncLastSyncedAt
     ? new Date(settings.cloudSyncLastSyncedAt).toLocaleString()
     : null;
+  const hasConfirmedCloudBackup = Boolean(settings.cloudSyncKeyId);
   const isGeneratingCloudSync = cloudSyncAction === 'generate';
   const isUploadingCloudSync = cloudSyncAction === 'upload';
   const isDownloadingCloudSync = cloudSyncAction === 'download';
@@ -596,6 +597,11 @@ export default function SettingsPage() {
     }
   }
 
+  function resetCloudSyncStatus() {
+    setCloudSyncError('');
+    setCloudSyncMessage('');
+  }
+
   async function handleCloudUpload() {
     if (!cloudSyncPhrase.trim()) {
       setCloudSyncError('Enter your sync code before uploading.');
@@ -608,8 +614,7 @@ export default function SettingsPage() {
       return;
     }
 
-    setCloudSyncError('');
-    setCloudSyncMessage('');
+    resetCloudSyncStatus();
     setCloudSyncAction('upload');
     try {
       await uploadWithPhrase(cloudSyncPhrase);
@@ -764,8 +769,7 @@ export default function SettingsPage() {
   }
 
   async function handleSyncNow() {
-    setCloudSyncError('');
-    setCloudSyncMessage('');
+    resetCloudSyncStatus();
 
     if (shouldWarnAboutEmptyUpload()) {
       setShowEmptySyncWarningDialog(true);
@@ -777,8 +781,6 @@ export default function SettingsPage() {
   }
 
   async function performSyncUpload() {
-    setCloudSyncError('');
-    setCloudSyncMessage('');
     setCloudSyncAction('sync');
     try {
       const phraseToUse = storedMnemonic || cloudSyncPhrase;
@@ -806,6 +808,7 @@ export default function SettingsPage() {
 
   async function handleUploadAnywayDespiteEmpty() {
     setShowEmptySyncWarningDialog(false);
+    resetCloudSyncStatus();
     await performSyncUpload();
   }
 
@@ -1445,7 +1448,7 @@ export default function SettingsPage() {
               Your local settings are empty
             </DialogTitle>
             <DialogDescription className="pt-2">
-              You have no cards or rules configured locally, but there's likely a cloud backup{' '}
+              You have no cards or rules configured locally, but {hasConfirmedCloudBackup ? 'you have a cloud backup' : "there's likely a cloud backup"}{' '}
               {cloudSyncLastSynced ? `from ${cloudSyncLastSynced}` : 'from another device'}. Uploading now would overwrite your cloud backup with empty settings.
               <br /><br />
               Would you like to download your settings from the cloud instead?


### PR DESCRIPTION
## Summary
- show a modal warning before any sync upload when local settings are empty and a backup probably exists
- keep users in advanced mode right after they choose to remember their sync code so they can collapse back to simple mode intentionally
- polish the empty-upload dialog copy so the fallback text is friendly on first-time devices

## Testing
- Not run (not requested)