### PR TITLE
Add dashboard rewind history controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Client-side tracker that analyses YNAB transactions to monitor credit card rewar
 - Connect via YNAB personal access token and track linked credit card accounts.
 - Define per-card reward rules with minimum/maximum spend limits and category mapping.
 - Real-time reward computation with normalised dollar comparisons and recommendations.
+- Rewind the dashboard by month to inspect historical reward totals and cycle progress.
 - Optional Cloud Sync with encrypted backups and automatic bidirectional sync.
 - Agent API for card limits, category guidance, and transaction advice (powered by Cloud Sync + PAT).
 - Web app built with Next.js 14, Tailwind CSS, and shadcn/ui.

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -192,6 +192,10 @@ function convertStoredCalculation(card: CreditCard, stored: RewardCalculation): 
     periodEnd = period.end;
   }
 
+  // Legacy stored calculations predate countedSpend, so fall back to the
+  // reward-eligible amount when present and otherwise to total spend.
+  const countedSpend = stored.eligibleSpend > 0 ? stored.eligibleSpend : stored.totalSpend;
+
   return {
     cardId: stored.cardId,
     period: stored.period,
@@ -199,6 +203,7 @@ function convertStoredCalculation(card: CreditCard, stored: RewardCalculation): 
     periodEnd,
     rewardType: stored.rewardType,
     totalSpend: stored.totalSpend,
+    countedSpend,
     eligibleSpend: stored.eligibleSpend,
     rewardEarned: stored.rewardEarned,
     rewardEarnedDollars: stored.rewardEarnedDollars ?? stored.rewardEarned,
@@ -221,6 +226,7 @@ function mapStoredSubcategories(
     name: entry.name,
     flagColor: entry.flagColor,
     totalSpend: entry.totalSpend,
+    countedSpend: entry.eligibleSpend > 0 ? entry.eligibleSpend : entry.totalSpend,
     eligibleSpend: entry.eligibleSpend,
     eligibleSpendBeforeBlocks: entry.eligibleSpendBeforeBlocks ?? entry.eligibleSpend,
     rewardEarned: entry.rewardEarned,

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -192,9 +192,9 @@ function convertStoredCalculation(card: CreditCard, stored: RewardCalculation): 
     periodEnd = period.end;
   }
 
-  // Legacy stored calculations predate countedSpend, so fall back to the
-  // reward-eligible amount when present and otherwise to total spend.
-  const countedSpend = stored.eligibleSpend > 0 ? stored.eligibleSpend : stored.totalSpend;
+  // Legacy stored calculations predate countedSpend, so use eligible spend when
+  // it is available even if it is legitimately zero.
+  const countedSpend = stored.eligibleSpend ?? stored.totalSpend;
 
   return {
     cardId: stored.cardId,
@@ -226,7 +226,7 @@ function mapStoredSubcategories(
     name: entry.name,
     flagColor: entry.flagColor,
     totalSpend: entry.totalSpend,
-    countedSpend: entry.eligibleSpend > 0 ? entry.eligibleSpend : entry.totalSpend,
+    countedSpend: entry.eligibleSpend ?? entry.totalSpend,
     eligibleSpend: entry.eligibleSpend,
     eligibleSpendBeforeBlocks: entry.eligibleSpendBeforeBlocks ?? entry.eligibleSpend,
     rewardEarned: entry.rewardEarned,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -117,7 +117,7 @@ function DashboardContent() {
   );
   const dashboardPeriod = useMemo(
     () => resolveDashboardPeriod(searchParams.get("asOf"), searchParams.get("month")),
-    [searchParams]
+    [searchParams, dayBoundaryTick]
   );
 
   // Tab state: "featured" (default) or "all"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -18,7 +18,13 @@ import { DashboardLanding } from "@/components/dashboard/DashboardLanding";
 import { SetupProgressAlert } from "@/components/dashboard/SetupProgressAlert";
 import { DashboardCardOverview } from "@/components/dashboard/DashboardCardOverview";
 import { AllCardsTab } from "@/components/dashboard/AllCardsTab";
+import { DashboardPeriodNavigator } from "@/components/dashboard/DashboardPeriodNavigator";
 import { useTrackedTransactions } from "@/hooks/useTrackedTransactions";
+import {
+  resolveDashboardPeriod,
+  shiftDashboardPeriodDays,
+  shiftDashboardPeriodMonths,
+} from "@/lib/dashboard-period";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -86,6 +92,33 @@ function DashboardContent() {
     isLoading: isViewModeLoading
   } = useDashboardViewMode();
   const { settings, updateSettings } = useSettings();
+  const [dayBoundaryTick, setDayBoundaryTick] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const now = new Date();
+    const nextMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    const timeoutMs = Math.max(1000, nextMidnight.getTime() - now.getTime() + 100);
+    const timeoutId = window.setTimeout(() => {
+      setDayBoundaryTick((tick) => tick + 1);
+    }, timeoutMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [dayBoundaryTick]);
+
+  const liveDashboardPeriod = useMemo(
+    () => resolveDashboardPeriod(null, null),
+    [dayBoundaryTick]
+  );
+  const dashboardPeriod = useMemo(
+    () => resolveDashboardPeriod(searchParams.get("asOf"), searchParams.get("month")),
+    [searchParams]
+  );
 
   // Tab state: "featured" (default) or "all"
   const [activeTab, setActiveTab] = useState<'featured' | 'all'>(() => {
@@ -123,6 +156,47 @@ function DashboardContent() {
     router.replace(newUrl);
   }, [pathname, router, searchParams]);
 
+  const handleDashboardDateChange = useCallback((dateValue: string | null) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete("month");
+    if (!dateValue || dateValue === liveDashboardPeriod.dateValue) {
+      params.delete("asOf");
+    } else {
+      params.set("asOf", dateValue);
+    }
+
+    const query = params.toString();
+    const newUrl = query ? `${pathname}?${query}` : pathname;
+    router.replace(newUrl);
+  }, [liveDashboardPeriod.dateValue, pathname, router, searchParams]);
+
+  const handlePreviousDay = useCallback(() => {
+    handleDashboardDateChange(shiftDashboardPeriodDays(dashboardPeriod.dateValue, -1));
+  }, [dashboardPeriod.dateValue, handleDashboardDateChange]);
+
+  const handleNextDay = useCallback(() => {
+    if (dashboardPeriod.isToday) {
+      return;
+    }
+    handleDashboardDateChange(shiftDashboardPeriodDays(dashboardPeriod.dateValue, 1));
+  }, [dashboardPeriod.dateValue, dashboardPeriod.isToday, handleDashboardDateChange]);
+
+  const handlePreviousMonth = useCallback(() => {
+    handleDashboardDateChange(shiftDashboardPeriodMonths(dashboardPeriod.dateValue, -1));
+  }, [dashboardPeriod.dateValue, handleDashboardDateChange]);
+
+  const handleNextMonth = useCallback(() => {
+    if (dashboardPeriod.isToday) {
+      return;
+    }
+    handleDashboardDateChange(shiftDashboardPeriodMonths(dashboardPeriod.dateValue, 1));
+  }, [dashboardPeriod.dateValue, dashboardPeriod.isToday, handleDashboardDateChange]);
+
+  const handleResetDate = useCallback(() => {
+    handleDashboardDateChange(null);
+  }, [handleDashboardDateChange]);
+
   const viewMode: DashboardViewMode = isViewModeLoading ? 'summary' : storedViewMode;
 
   const handleViewModeChange = useCallback(
@@ -154,9 +228,14 @@ function DashboardContent() {
   );
 
   const visibleFeaturedCards = useMemo(
-    () => featuredCards.filter((card) => !isCardHidden(card.id)),
-    [featuredCards, isCardHidden]
+    () => (
+      dashboardPeriod.isToday
+        ? featuredCards.filter((card) => !isCardHidden(card.id))
+        : featuredCards
+    ),
+    [dashboardPeriod.isToday, featuredCards, isCardHidden]
   );
+  const effectiveHiddenCards = dashboardPeriod.isToday ? hiddenCards : [];
 
   const applyStoredOrdering = useCallback(
     (list: CreditCard[], category: 'cashback' | 'miles' | 'all') => {
@@ -195,6 +274,7 @@ function DashboardContent() {
     featuredCards,
     lookbackDays: TRANSACTION_LOOKBACK_DAYS,
     recentLimit: RECENT_TRANSACTIONS_LIMIT,
+    referenceDate: dashboardPeriod.referenceDate,
   });
 
   useEffect(() => {
@@ -235,14 +315,15 @@ function DashboardContent() {
   // Group and sort cards
   const { cashbackCards, milesCards, allCards } = useMemo(() => {
     const now = new Date();
+    const sortReferenceDate = dashboardPeriod.referenceDate;
 
     const getDaysRemaining = (card: (typeof cards)[0]) => {
-      const period = SimpleRewardsCalculator.calculatePeriod(card);
+      const period = SimpleRewardsCalculator.calculatePeriod(card, sortReferenceDate);
       const periodDate = {
         startDate: new Date(period.start),
         endDate: new Date(period.end)
       };
-      return clampDaysLeft(periodDate, now);
+      return clampDaysLeft(periodDate, sortReferenceDate);
     };
 
     const cashback = visibleFeaturedCards.filter((c) => c.type === "cashback");
@@ -256,7 +337,7 @@ function DashboardContent() {
     const orderedAll = applyStoredOrdering([...orderedCashback, ...orderedMiles], 'all');
 
     return { cashbackCards: orderedCashback, milesCards: orderedMiles, allCards: orderedAll };
-  }, [visibleFeaturedCards, applyStoredOrdering]);
+  }, [visibleFeaturedCards, applyStoredOrdering, dashboardPeriod.referenceDate]);
 
   const cashbackCollapsed = settings.collapsedCardGroups?.cashback ?? false;
   const milesCollapsed = settings.collapsedCardGroups?.miles ?? false;
@@ -334,14 +415,14 @@ function DashboardContent() {
   return (
     <div className="max-w-6xl mx-auto px-6 py-8">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-6">
-        <div className="flex items-center gap-4">
+        <div className="flex min-w-0 items-center gap-4">
           <h1 className="text-3xl font-bold">Dashboard</h1>
-          <div className="flex items-center rounded-lg border bg-muted/30 p-0.5">
+          <div className="shrink-0 flex items-center rounded-lg border bg-muted/30 p-0.5">
             <button
               type="button"
               onClick={() => handleTabChange('featured')}
               className={cn(
-                "px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
+                "whitespace-nowrap px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
                 activeTab === 'featured'
                   ? "bg-background shadow-sm text-foreground"
                   : "text-muted-foreground hover:text-foreground"
@@ -353,7 +434,7 @@ function DashboardContent() {
               type="button"
               onClick={() => handleTabChange('all')}
               className={cn(
-                "px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
+                "whitespace-nowrap px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
                 activeTab === 'all'
                   ? "bg-background shadow-sm text-foreground"
                   : "text-muted-foreground hover:text-foreground"
@@ -364,43 +445,63 @@ function DashboardContent() {
           </div>
         </div>
         {activeTab === 'featured' && (
-          <div className="flex items-center gap-3">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="gap-1.5">
-                  {viewMode === "summary" ? (
-                    <LayoutGrid className="h-4 w-4" />
-                  ) : (
-                    <List className="h-4 w-4" />
-                  )}
-                  <span className="hidden sm:inline">
-                    {viewMode === "summary" ? "Summary" : "Detailed"}
-                  </span>
-                  <ChevronDown className="h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuRadioGroup
-                  value={viewMode}
-                  onValueChange={(v) => handleViewModeChange(v as DashboardViewMode)}
-                >
-                  <DropdownMenuRadioItem value="summary">
-                    Summary view
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="detailed">
-                    Detailed view
-                  </DropdownMenuRadioItem>
-                </DropdownMenuRadioGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuCheckboxItem
-                  checked={groupByType}
-                  onCheckedChange={handleGroupByTypeToggle}
-                >
-                  Group by card type
-                </DropdownMenuCheckboxItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <div className="flex items-center gap-2">
+          <div className="flex w-full items-center justify-between gap-2 md:ml-auto md:w-auto md:shrink-0 md:justify-end">
+            <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto pb-1 sm:gap-2 sm:overflow-visible sm:pb-0">
+              <DashboardPeriodNavigator
+                dateValue={dashboardPeriod.dateValue}
+                monthLabel={dashboardPeriod.monthLabel}
+                asOfLabel={dashboardPeriod.asOfLabel}
+                triggerLabel={dashboardPeriod.triggerLabel}
+                maxDateValue={liveDashboardPeriod.dateValue}
+                isToday={dashboardPeriod.isToday}
+                onPreviousDay={handlePreviousDay}
+                onNextDay={handleNextDay}
+                onPreviousMonth={handlePreviousMonth}
+                onNextMonth={handleNextMonth}
+                onReset={handleResetDate}
+                onDateChange={handleDashboardDateChange}
+              />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 data-[state=open]:bg-red-50 data-[state=open]:text-red-700 hover:data-[state=open]:bg-red-50 hover:data-[state=open]:text-red-700 dark:data-[state=open]:bg-red-950/40 dark:data-[state=open]:text-red-300"
+                  >
+                    {viewMode === "summary" ? (
+                      <LayoutGrid className="h-4 w-4" />
+                    ) : (
+                      <List className="h-4 w-4" />
+                    )}
+                    <span className="hidden sm:inline">
+                      {viewMode === "summary" ? "Summary" : "Detailed"}
+                    </span>
+                    <ChevronDown className="h-3 w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuRadioGroup
+                    value={viewMode}
+                    onValueChange={(v) => handleViewModeChange(v as DashboardViewMode)}
+                  >
+                    <DropdownMenuRadioItem value="summary">
+                      Summary view
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="detailed">
+                      Detailed view
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuCheckboxItem
+                    checked={groupByType}
+                    onCheckedChange={handleGroupByTypeToggle}
+                  >
+                    Group by card type
+                  </DropdownMenuCheckboxItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <div className="ml-auto flex shrink-0 items-center gap-2">
               <Button
                 type="button"
                 size="sm"
@@ -443,7 +544,7 @@ function DashboardContent() {
           milesCards={milesCards}
           allCards={allCards}
           visibleFeaturedCards={visibleFeaturedCards}
-          hiddenCards={hiddenCards}
+          hiddenCards={effectiveHiddenCards}
           viewMode={viewMode}
           onHideCard={hideCard}
           onUnhideAll={handleUnhideAll}
@@ -457,6 +558,8 @@ function DashboardContent() {
           onToggleGroup={handleToggleGroup}
           onReorderCards={handleCardReorder}
           groupByType={groupByType}
+          referenceDate={dashboardPeriod.referenceDate}
+          allowHideCards={dashboardPeriod.isToday}
         />
       ) : (
         <AllCardsTab initialCardId={initialCardId} />

--- a/apps/web/components/CardSpendingSummary.tsx
+++ b/apps/web/components/CardSpendingSummary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
+import { formatDateValue } from '@/lib/dashboard-period';
 import { SimpleRewardsCalculator } from '@/lib/rewards-engine';
 import { YnabClient } from '@/lib/ynab-client';
 import { storage } from '@/lib/storage';
@@ -18,13 +19,6 @@ import {
 } from '@/lib/minimum-spend-helpers';
 import type { CreditCard } from '@/lib/storage';
 import type { Transaction } from '@/types/transaction';
-
-function formatAsOfDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
 
 interface CardSpendingSummaryProps {
   card: CreditCard;
@@ -61,7 +55,7 @@ export function CardSpendingSummary({
     [card, referenceDate]
   );
   const asOfDate = useMemo(
-    () => formatAsOfDate(referenceDate ?? new Date()),
+    () => formatDateValue(referenceDate ?? new Date()),
     [referenceDate]
   );
   const calculationPeriod = useMemo(
@@ -75,7 +69,7 @@ export function CardSpendingSummary({
   // Use prefetched budget-wide transactions if provided; otherwise fetch
   const loadTransactions = useCallback(async () => {
     // Use prefetched data path
-    if (prefetchedTransactions && prefetchedTransactions.length >= 0) {
+    if (prefetchedTransactions) {
       const cardTxns = prefetchedTransactions.filter((t: Transaction) =>
         t.account_id === card.ynabAccountId &&
           t.date >= calculationPeriod.start &&

--- a/apps/web/components/CardSpendingSummary.tsx
+++ b/apps/web/components/CardSpendingSummary.tsx
@@ -19,6 +19,13 @@ import {
 import type { CreditCard } from '@/lib/storage';
 import type { Transaction } from '@/types/transaction';
 
+function formatAsOfDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 interface CardSpendingSummaryProps {
   card: CreditCard;
   pat?: string;
@@ -28,9 +35,20 @@ interface CardSpendingSummaryProps {
   onHideCard?: (cardId: string, hiddenUntil: string) => void;
   showHideOption?: boolean;
   isRefreshing?: boolean;
+  referenceDate?: Date;
+  allowHideCard?: boolean;
 }
 
-export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideCard, showHideOption, isRefreshing }: CardSpendingSummaryProps) {
+export function CardSpendingSummary({
+  card,
+  pat,
+  prefetchedTransactions,
+  onHideCard,
+  showHideOption,
+  isRefreshing,
+  referenceDate,
+  allowHideCard = true,
+}: CardSpendingSummaryProps) {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const abortRef = useRef<AbortController | null>(null);
@@ -38,8 +56,21 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
   const { selectedBudget } = useSelectedBudget();
   const flagNames = useMemo(() => storage.getFlagNames(), []);
 
-  // Calculate current period
-  const period = useMemo(() => SimpleRewardsCalculator.calculatePeriod(card), [card]);
+  const period = useMemo(
+    () => SimpleRewardsCalculator.calculatePeriod(card, referenceDate),
+    [card, referenceDate]
+  );
+  const asOfDate = useMemo(
+    () => formatAsOfDate(referenceDate ?? new Date()),
+    [referenceDate]
+  );
+  const calculationPeriod = useMemo(
+    () => ({
+      ...period,
+      end: period.end < asOfDate ? period.end : asOfDate,
+    }),
+    [asOfDate, period]
+  );
 
   // Use prefetched budget-wide transactions if provided; otherwise fetch
   const loadTransactions = useCallback(async () => {
@@ -47,8 +78,8 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
     if (prefetchedTransactions && prefetchedTransactions.length >= 0) {
       const cardTxns = prefetchedTransactions.filter((t: Transaction) =>
         t.account_id === card.ynabAccountId &&
-          t.date >= period.start &&
-          t.date <= period.end
+          t.date >= calculationPeriod.start &&
+          t.date <= calculationPeriod.end
       );
 
       setTransactions(cardTxns);
@@ -78,11 +109,13 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
 
     try {
       const allTxns = await client.getTransactions(budgetId, {
-        since_date: period.start,
+        since_date: calculationPeriod.start,
         signal: controller.signal,
       });
       const cardTxns = allTxns.filter((t: Transaction) =>
-        t.account_id === card.ynabAccountId && t.date <= period.end
+        t.account_id === card.ynabAccountId &&
+          t.date >= calculationPeriod.start &&
+          t.date <= calculationPeriod.end
       );
       setTransactions(cardTxns);
     } catch (error) {
@@ -95,7 +128,7 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
         abortRef.current = null;
       }
     }
-  }, [prefetchedTransactions, pat, card.ynabAccountId, period, selectedBudget.id]);
+  }, [prefetchedTransactions, pat, card.ynabAccountId, calculationPeriod, selectedBudget.id]);
 
   useEffect(() => {
     loadTransactions();
@@ -112,14 +145,12 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
     const calculation = SimpleRewardsCalculator.calculateCardRewards(
       card,
       transactions,
-      period,
+      calculationPeriod,
       settings || undefined
     );
 
-    // Calculate days remaining
-    const now = new Date();
     const end = new Date(period.end);
-    const diff = end.getTime() - now.getTime();
+    const diff = end.getTime() - (referenceDate ?? new Date()).getTime();
     const daysRemaining = Math.ceil(diff / (1000 * 60 * 60 * 24));
 
     return {
@@ -138,7 +169,7 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
       maximumSpendProgress: calculation.maximumSpendProgress,
       subcategoryBreakdowns: calculation.subcategoryBreakdowns ?? [],
     };
-  }, [card, transactions, period, settings]);
+  }, [calculationPeriod, card, period.end, referenceDate, settings, transactions]);
 
   if (loading) {
     return (
@@ -255,7 +286,7 @@ export function CardSpendingSummary({ card, pat, prefetchedTransactions, onHideC
               <span>Stop using - max reached</span>
             </div>
           )}
-          {maximumSpendExceeded && showHideOption && onHideCard && (
+          {allowHideCard && maximumSpendExceeded && showHideOption && onHideCard && (
             <Button
               variant="outline"
               size="sm"

--- a/apps/web/components/CardSummaryCompact.tsx
+++ b/apps/web/components/CardSummaryCompact.tsx
@@ -19,15 +19,32 @@ import type { Transaction } from "@/types/transaction";
 const isExpansionMap = (value: unknown): value is Record<string, boolean> =>
   value !== undefined && typeof value === "object" && value !== null && !Array.isArray(value);
 
+function formatAsOfDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 interface CardSummaryCompactProps {
   card: CreditCard;
   pat?: string;
   prefetchedTransactions?: Transaction[];
   onHideCard?: (cardId: string, hiddenUntil: string) => void;
   isRefreshing?: boolean;
+  referenceDate?: Date;
+  allowHideCard?: boolean;
 }
 
-export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCard, isRefreshing }: CardSummaryCompactProps) {
+export function CardSummaryCompact({
+  card,
+  pat,
+  prefetchedTransactions,
+  onHideCard,
+  isRefreshing,
+  referenceDate,
+  allowHideCard = true,
+}: CardSummaryCompactProps) {
   const { settings, updateSettings } = useSettings();
   const { selectedBudget } = useSelectedBudget();
 
@@ -35,13 +52,29 @@ export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCa
   const [loading, setLoading] = useState(true);
   const abortRef = useRef<AbortController | null>(null);
 
-  const period = useMemo(() => SimpleRewardsCalculator.calculatePeriod(card), [card]);
+  const period = useMemo(
+    () => SimpleRewardsCalculator.calculatePeriod(card, referenceDate),
+    [card, referenceDate]
+  );
+  const asOfDate = useMemo(
+    () => formatAsOfDate(referenceDate ?? new Date()),
+    [referenceDate]
+  );
+  const calculationPeriod = useMemo(
+    () => ({
+      ...period,
+      end: period.end < asOfDate ? period.end : asOfDate,
+    }),
+    [asOfDate, period]
+  );
   const flagNames = useMemo(() => storage.getFlagNames(), []);
 
   const loadTransactions = useCallback(async () => {
     if (prefetchedTransactions) {
       const cardTxns = prefetchedTransactions.filter((txn) =>
-        txn.account_id === card.ynabAccountId && txn.date >= period.start && txn.date <= period.end
+        txn.account_id === card.ynabAccountId &&
+        txn.date >= calculationPeriod.start &&
+        txn.date <= calculationPeriod.end
       );
       setTransactions(cardTxns);
       setLoading(false);
@@ -68,11 +101,14 @@ export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCa
 
     try {
       const allTxns = await client.getTransactions(selectedBudget.id, {
-        since_date: period.start,
+        since_date: calculationPeriod.start,
         signal: controller.signal,
       });
       const cardTxns = allTxns.filter(
-        (txn: Transaction) => txn.account_id === card.ynabAccountId && txn.date <= period.end
+        (txn: Transaction) =>
+          txn.account_id === card.ynabAccountId &&
+          txn.date >= calculationPeriod.start &&
+          txn.date <= calculationPeriod.end
       );
       setTransactions(cardTxns);
     } catch (error) {
@@ -85,7 +121,7 @@ export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCa
         abortRef.current = null;
       }
     }
-  }, [prefetchedTransactions, pat, card.ynabAccountId, period, selectedBudget.id]);
+  }, [prefetchedTransactions, pat, card.ynabAccountId, calculationPeriod, selectedBudget.id]);
 
   useEffect(() => {
     loadTransactions();
@@ -99,13 +135,12 @@ export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCa
     const calculation = SimpleRewardsCalculator.calculateCardRewards(
       card,
       transactions,
-      period,
+      calculationPeriod,
       settings || undefined
     );
 
-    const now = new Date();
     const end = new Date(period.end);
-    const diff = end.getTime() - now.getTime();
+    const diff = end.getTime() - (referenceDate ?? new Date()).getTime();
     const daysRemaining = Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
 
     return {
@@ -118,7 +153,7 @@ export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCa
       daysRemaining,
       subcategoryBreakdowns: calculation.subcategoryBreakdowns ?? [],
     };
-  }, [card, transactions, period, settings]);
+  }, [calculationPeriod, card, period.end, referenceDate, settings, transactions]);
 
   const summaryViewExpansionSetting = settings?.summaryViewSubcategoriesExpanded;
 
@@ -294,7 +329,7 @@ export function CardSummaryCompact({ card, pat, prefetchedTransactions, onHideCa
           </span>
         </div>
 
-        {maximumSpendExceeded && onHideCard && (
+        {allowHideCard && maximumSpendExceeded && onHideCard && (
           <Button
             variant="ghost"
             size="sm"

--- a/apps/web/components/CardSummaryCompact.tsx
+++ b/apps/web/components/CardSummaryCompact.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sparkles } from "lucide-react";
+import { formatDateValue } from "@/lib/dashboard-period";
 import { SimpleRewardsCalculator } from "@/lib/rewards-engine";
 import { YnabClient } from "@/lib/ynab-client";
 import { useSelectedBudget, useSettings } from "@/hooks/useLocalStorage";
@@ -18,13 +19,6 @@ import type { Transaction } from "@/types/transaction";
 
 const isExpansionMap = (value: unknown): value is Record<string, boolean> =>
   value !== undefined && typeof value === "object" && value !== null && !Array.isArray(value);
-
-function formatAsOfDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 interface CardSummaryCompactProps {
   card: CreditCard;
@@ -57,7 +51,7 @@ export function CardSummaryCompact({
     [card, referenceDate]
   );
   const asOfDate = useMemo(
-    () => formatAsOfDate(referenceDate ?? new Date()),
+    () => formatDateValue(referenceDate ?? new Date()),
     [referenceDate]
   );
   const calculationPeriod = useMemo(

--- a/apps/web/components/dashboard/DashboardCardOverview.tsx
+++ b/apps/web/components/dashboard/DashboardCardOverview.tsx
@@ -112,6 +112,8 @@ interface DashboardCardOverviewProps {
   onToggleGroup(category: 'cashback' | 'miles'): void;
   onReorderCards(category: 'cashback' | 'miles' | 'all', orderedIds: string[]): void;
   groupByType?: boolean;
+  referenceDate?: Date;
+  allowHideCards?: boolean;
 }
 
 
@@ -135,6 +137,8 @@ export function DashboardCardOverview({
   onToggleGroup,
   onReorderCards,
   groupByType = true,
+  referenceDate,
+  allowHideCards = true,
 }: DashboardCardOverviewProps) {
   const hiddenCount = hiddenCards.length;
   const hasVisibleCards = visibleFeaturedCards.length > 0;
@@ -226,6 +230,8 @@ export function DashboardCardOverview({
           onReorderCards={(orderedIds) => onReorderCards('all', orderedIds)}
           isRefreshing={transactionsRefreshing}
           showTypeBadge
+          referenceDate={referenceDate}
+          allowHideCards={allowHideCards}
         />
       );
     }
@@ -247,6 +253,8 @@ export function DashboardCardOverview({
             onToggleCollapse={() => onToggleGroup('cashback')}
             onReorderCards={(orderedIds) => onReorderCards('cashback', orderedIds)}
             isRefreshing={transactionsRefreshing}
+            referenceDate={referenceDate}
+            allowHideCards={allowHideCards}
           />
         )}
         {milesCards.length > 0 && (
@@ -263,6 +271,8 @@ export function DashboardCardOverview({
             onToggleCollapse={() => onToggleGroup('miles')}
             onReorderCards={(orderedIds) => onReorderCards('miles', orderedIds)}
             isRefreshing={transactionsRefreshing}
+            referenceDate={referenceDate}
+            allowHideCards={allowHideCards}
           />
         )}
       </>
@@ -287,6 +297,8 @@ export function DashboardCardOverview({
     transactionsRefreshing,
     groupByType,
     visibleFeaturedCards,
+    referenceDate,
+    allowHideCards,
   ]);
 
   return (
@@ -326,6 +338,8 @@ interface CardGroupProps {
   onReorderCards(orderedIds: string[]): void;
   isRefreshing: boolean;
   showTypeBadge?: boolean;
+  referenceDate?: Date;
+  allowHideCards: boolean;
 }
 
 function CardGroup({
@@ -342,6 +356,8 @@ function CardGroup({
   onReorderCards,
   isRefreshing,
   showTypeBadge = false,
+  referenceDate,
+  allowHideCards,
 }: CardGroupProps) {
   const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const sensors = useSensors(
@@ -452,6 +468,8 @@ function CardGroup({
                     isSorting={Boolean(activeDragId)}
                     isRefreshing={isRefreshing}
                     showTypeBadge={showTypeBadge}
+                    referenceDate={referenceDate}
+                    allowHideCard={allowHideCards}
                   />
                 );
               })}
@@ -474,9 +492,22 @@ interface SortableDashboardCardProps {
   isSorting: boolean;
   isRefreshing: boolean;
   showTypeBadge?: boolean;
+  referenceDate?: Date;
+  allowHideCard: boolean;
 }
 
-function SortableDashboardCard({ card, viewMode, pat, prefetchedTransactions, onHideCard, isSorting, isRefreshing, showTypeBadge = false }: SortableDashboardCardProps) {
+function SortableDashboardCard({
+  card,
+  viewMode,
+  pat,
+  prefetchedTransactions,
+  onHideCard,
+  isSorting,
+  isRefreshing,
+  showTypeBadge = false,
+  referenceDate,
+  allowHideCard,
+}: SortableDashboardCardProps) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
     id: card.id,
   });
@@ -566,13 +597,15 @@ function SortableDashboardCard({ card, viewMode, pat, prefetchedTransactions, on
                 <Settings2 className="h-4 w-4 mr-2" />
                 Edit settings
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => {
-                const period = SimpleRewardsCalculator.calculatePeriod(card);
-                onHideCard(card.id, period.end);
-              }}>
-                <EyeOff className="h-4 w-4 mr-2" />
-                Hide from dashboard
-              </DropdownMenuItem>
+              {allowHideCard && (
+                <DropdownMenuItem onClick={() => {
+                  const period = SimpleRewardsCalculator.calculatePeriod(card, referenceDate);
+                  onHideCard(card.id, period.end);
+                }}>
+                  <EyeOff className="h-4 w-4 mr-2" />
+                  Hide from dashboard
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem onClick={() => { window.location.href = `/cards/${card.id}`; }}>
                 <ReceiptText className="h-4 w-4 mr-2" />
                 View transactions
@@ -653,6 +686,8 @@ function SortableDashboardCard({ card, viewMode, pat, prefetchedTransactions, on
               onHideCard={onHideCard}
               showHideOption
               isRefreshing={isRefreshing}
+              referenceDate={referenceDate}
+              allowHideCard={allowHideCard}
             />
           ) : (
             <CardSummaryCompact
@@ -661,6 +696,8 @@ function SortableDashboardCard({ card, viewMode, pat, prefetchedTransactions, on
               prefetchedTransactions={prefetchedTransactions}
               onHideCard={onHideCard}
               isRefreshing={isRefreshing}
+              referenceDate={referenceDate}
+              allowHideCard={allowHideCard}
             />
           )}
         </CardContent>

--- a/apps/web/components/dashboard/DashboardPeriodNavigator.tsx
+++ b/apps/web/components/dashboard/DashboardPeriodNavigator.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  CalendarDays,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  History,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface DashboardPeriodNavigatorProps {
+  dateValue: string;
+  monthLabel: string;
+  asOfLabel: string;
+  triggerLabel: string;
+  maxDateValue: string;
+  isToday: boolean;
+  onPreviousDay(): void;
+  onNextDay(): void;
+  onPreviousMonth(): void;
+  onNextMonth(): void;
+  onReset(): void;
+  onDateChange(value: string): void;
+}
+
+interface StepperRowProps {
+  label: string;
+  backLabel: string;
+  forwardLabel: string;
+  onBack(): void;
+  onForward(): void;
+  disableForward?: boolean;
+  backIcon: ReactNode;
+  forwardIcon: ReactNode;
+}
+
+function StepperRow({
+  label,
+  backLabel,
+  forwardLabel,
+  onBack,
+  onForward,
+  disableForward = false,
+  backIcon,
+  forwardIcon,
+}: StepperRowProps) {
+  return (
+    <div className="flex items-center justify-between rounded-lg border bg-muted/20 px-3 py-2">
+      <span className="text-sm font-medium">{label}</span>
+      <div className="flex items-center gap-1">
+        <Button type="button" variant="ghost" size="icon" className="h-8 w-8" onClick={onBack} aria-label={backLabel}>
+          {backIcon}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onForward}
+          disabled={disableForward}
+          aria-label={forwardLabel}
+        >
+          {forwardIcon}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function DashboardPeriodNavigator({
+  dateValue,
+  monthLabel,
+  asOfLabel,
+  triggerLabel,
+  maxDateValue,
+  isToday,
+  onPreviousDay,
+  onNextDay,
+  onPreviousMonth,
+  onNextMonth,
+  onReset,
+  onDateChange,
+}: DashboardPeriodNavigatorProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="group shrink-0 gap-1.5 px-2.5 data-[state=open]:bg-red-50 data-[state=open]:text-red-700 hover:data-[state=open]:bg-red-50 hover:data-[state=open]:text-red-700 dark:data-[state=open]:bg-red-950/40 dark:data-[state=open]:text-red-300"
+        >
+          <span className="flex items-center gap-2">
+            {isToday ? <CalendarDays className="h-4 w-4" /> : <History className="h-4 w-4" />}
+            <span>{triggerLabel}</span>
+          </span>
+          <ChevronDown className="h-3 w-3 text-muted-foreground transition-colors group-data-[state=open]:text-red-600 dark:group-data-[state=open]:text-red-300" />
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        className="w-[calc(100vw-2rem)] max-w-sm space-y-3 p-3 sm:w-80"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+              {isToday ? <CalendarDays className="h-3.5 w-3.5" /> : <History className="h-3.5 w-3.5" />}
+              <span>{isToday ? "Live snapshot" : "Historical snapshot"}</span>
+            </div>
+            <div className="text-base font-semibold">{asOfLabel}</div>
+            <div className="text-sm text-muted-foreground">{monthLabel}</div>
+          </div>
+
+          {!isToday && (
+            <Button type="button" variant="ghost" size="sm" className="h-8 px-2 text-xs" onClick={onReset}>
+              Today
+            </Button>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="dashboard-as-of-date" className="text-xs font-medium text-muted-foreground">
+            Jump to date
+          </label>
+          <Input
+            id="dashboard-as-of-date"
+            type="date"
+            value={dateValue}
+            max={maxDateValue}
+            onChange={(event) => onDateChange(event.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <StepperRow
+            label="Day"
+            backLabel="Go back 1 day"
+            forwardLabel="Go forward 1 day"
+            onBack={onPreviousDay}
+            onForward={onNextDay}
+            disableForward={isToday}
+            backIcon={<ChevronLeft className="h-4 w-4" />}
+            forwardIcon={<ChevronRight className="h-4 w-4" />}
+          />
+          <StepperRow
+            label="Month"
+            backLabel="Go back 1 month"
+            forwardLabel="Go forward 1 month"
+            onBack={onPreviousMonth}
+            onForward={onNextMonth}
+            disableForward={isToday}
+            backIcon={<ChevronsLeft className="h-4 w-4" />}
+            forwardIcon={<ChevronsRight className="h-4 w-4" />}
+          />
+        </div>
+
+        <div
+          className={cn(
+            "rounded-lg border px-3 py-2 text-xs",
+            isToday
+              ? "border-emerald-200 bg-emerald-50/60 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300"
+              : "border-amber-200 bg-amber-50/60 text-amber-700 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300"
+          )}
+        >
+          {isToday
+            ? "Live mode shows rewards with today’s current progress."
+            : "Rewind mode shows rewards and spend as they stood on the selected day."}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/hooks/useTrackedTransactions.ts
+++ b/apps/web/hooks/useTrackedTransactions.ts
@@ -48,6 +48,7 @@ interface UseTrackedTransactionsArgs {
   featuredCards: CreditCard[];
   lookbackDays: number;
   recentLimit?: number;
+  referenceDate?: Date;
 }
 
 interface UseTrackedTransactionsResult {
@@ -79,6 +80,7 @@ export function useTrackedTransactions({
   featuredCards,
   lookbackDays,
   recentLimit,
+  referenceDate,
 }: UseTrackedTransactionsArgs): UseTrackedTransactionsResult {
   const [allTransactions, setAllTransactions] = useState<Transaction[]>([]);
   const [accountsMap, setAccountsMap] = useState<Map<string, string>>(new Map());
@@ -91,19 +93,21 @@ export function useTrackedTransactions({
   const lastFetchKeyRef = useRef("");
 
   const earliestTrackedWindow = useMemo(() => {
+    const anchorDate = referenceDate ?? new Date();
+
     if (featuredCards.length === 0) {
-      const fallback = new Date();
+      const fallback = new Date(anchorDate);
       fallback.setDate(fallback.getDate() - lookbackDays);
       return fallback.toISOString().split("T")[0];
     }
 
     const earliestMillis = featuredCards
-      .map((card) => SimpleRewardsCalculator.calculatePeriod(card))
+      .map((card) => SimpleRewardsCalculator.calculatePeriod(card, anchorDate))
       .map((period) => new Date(period.start).getTime())
       .reduce((min, current) => Math.min(min, current), Number.POSITIVE_INFINITY);
 
     return new Date(earliestMillis).toISOString().split("T")[0];
-  }, [featuredCards, lookbackDays]);
+  }, [featuredCards, lookbackDays, referenceDate]);
 
   const loadTransactions = useCallback(async () => {
     if (!pat || !selectedBudgetId) {

--- a/apps/web/lib/dashboard-period.test.ts
+++ b/apps/web/lib/dashboard-period.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDateValue,
+  resolveDashboardPeriod,
+  shiftDashboardPeriodDays,
+  shiftDashboardPeriodMonths,
+} from "./dashboard-period";
+
+describe("resolveDashboardPeriod", () => {
+  const now = new Date(2026, 3, 4, 15, 30);
+
+  it("uses the live current day when no selection is provided", () => {
+    const period = resolveDashboardPeriod(null, null, now);
+
+    expect(period.dateValue).toBe("2026-04-04");
+    expect(period.isToday).toBe(true);
+    expect(period.referenceDate).toEqual(now);
+  });
+
+  it("supports an explicit as-at date", () => {
+    const period = resolveDashboardPeriod("2026-03-18", null, now);
+
+    expect(period.dateValue).toBe("2026-03-18");
+    expect(period.monthValue).toBe("2026-03");
+    expect(period.isToday).toBe(false);
+    expect(period.referenceDate).toEqual(new Date(2026, 2, 18));
+  });
+
+  it("falls back to the legacy month param by choosing that month end", () => {
+    const period = resolveDashboardPeriod(null, "2026-03", now);
+
+    expect(period.dateValue).toBe("2026-03-31");
+    expect(period.isToday).toBe(false);
+  });
+
+  it("clamps future dates back to today", () => {
+    const period = resolveDashboardPeriod("2026-05-01", null, now);
+
+    expect(period.dateValue).toBe("2026-04-04");
+    expect(period.isToday).toBe(true);
+    expect(period.referenceDate).toEqual(now);
+  });
+});
+
+describe("shiftDashboardPeriodDays", () => {
+  const now = new Date(2026, 3, 4);
+
+  it("moves one day at a time", () => {
+    expect(shiftDashboardPeriodDays("2026-04-04", -1, now)).toBe("2026-04-03");
+    expect(shiftDashboardPeriodDays("2026-04-03", 1, now)).toBe("2026-04-04");
+  });
+
+  it("does not move beyond today", () => {
+    expect(shiftDashboardPeriodDays("2026-04-04", 1, now)).toBe("2026-04-04");
+  });
+});
+
+describe("shiftDashboardPeriodMonths", () => {
+  const now = new Date(2026, 3, 4);
+
+  it("moves one month at a time while preserving day when possible", () => {
+    expect(shiftDashboardPeriodMonths("2026-04-04", -1, now)).toBe("2026-03-04");
+  });
+
+  it("clamps overflowed month lengths", () => {
+    expect(shiftDashboardPeriodMonths("2026-03-31", -1, now)).toBe("2026-02-28");
+  });
+
+  it("does not move beyond today", () => {
+    expect(shiftDashboardPeriodMonths("2026-03-31", 1, now)).toBe(formatDateValue(now));
+  });
+});

--- a/apps/web/lib/dashboard-period.ts
+++ b/apps/web/lib/dashboard-period.ts
@@ -1,0 +1,153 @@
+function truncateDate(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function endOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function isSameDay(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+function isSameMonth(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
+}
+
+function parseMonthValue(value: string | null | undefined): Date | null {
+  if (!value || !/^\d{4}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearRaw, monthRaw] = value.split("-");
+  const year = Number(yearRaw);
+  const monthIndex = Number(monthRaw) - 1;
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || monthIndex < 0 || monthIndex > 11) {
+    return null;
+  }
+
+  return new Date(year, monthIndex, 1);
+}
+
+function parseDateValue(value: string | null | undefined): Date | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearRaw, monthRaw, dayRaw] = value.split("-");
+  const year = Number(yearRaw);
+  const monthIndex = Number(monthRaw) - 1;
+  const day = Number(dayRaw);
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  const parsed = new Date(year, monthIndex, day);
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== monthIndex ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function formatMonthValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+export function formatDateValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function clampToToday(date: Date, today: Date): Date {
+  return date > today ? today : date;
+}
+
+export interface DashboardPeriodSelection {
+  dateValue: string;
+  monthValue: string;
+  referenceDate: Date;
+  isToday: boolean;
+  isCurrentMonth: boolean;
+  monthLabel: string;
+  asOfLabel: string;
+  triggerLabel: string;
+}
+
+export function resolveDashboardPeriod(
+  asOfValue: string | null | undefined,
+  legacyMonthValue: string | null | undefined,
+  now: Date = new Date()
+): DashboardPeriodSelection {
+  const today = truncateDate(now);
+  const parsedAsOf = parseDateValue(asOfValue);
+  const parsedLegacyMonth = parseMonthValue(legacyMonthValue);
+  const requestedDate = parsedAsOf ?? (parsedLegacyMonth ? endOfMonth(parsedLegacyMonth) : null) ?? today;
+  const safeDate = clampToToday(requestedDate, today);
+  const isToday = isSameDay(safeDate, today);
+  const referenceDate = isToday ? now : safeDate;
+
+  return {
+    dateValue: formatDateValue(safeDate),
+    monthValue: formatMonthValue(safeDate),
+    referenceDate,
+    isToday,
+    isCurrentMonth: isSameMonth(safeDate, today),
+    monthLabel: safeDate.toLocaleDateString(undefined, {
+      month: "long",
+      year: "numeric",
+    }),
+    asOfLabel: safeDate.toLocaleDateString(undefined, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    }),
+    triggerLabel: isToday
+      ? "Today"
+      : safeDate.toLocaleDateString(undefined, {
+          day: "numeric",
+          month: "short",
+        }),
+  };
+}
+
+export function shiftDashboardPeriodDays(
+  dateValue: string,
+  deltaDays: number,
+  now: Date = new Date()
+): string {
+  const today = truncateDate(now);
+  const baseDate = parseDateValue(dateValue) ?? today;
+  const shifted = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate() + deltaDays);
+  return formatDateValue(clampToToday(shifted, today));
+}
+
+export function shiftDashboardPeriodMonths(
+  dateValue: string,
+  deltaMonths: number,
+  now: Date = new Date()
+): string {
+  const today = truncateDate(now);
+  const baseDate = parseDateValue(dateValue) ?? today;
+  const targetYear = baseDate.getFullYear();
+  const targetMonth = baseDate.getMonth() + deltaMonths;
+  const lastDayOfTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
+  const targetDay = Math.min(baseDate.getDate(), lastDayOfTargetMonth);
+  const shifted = new Date(targetYear, targetMonth, targetDay);
+
+  return formatDateValue(clampToToday(shifted, today));
+}

--- a/packages/app-core/src/rewards-engine/simple-calculator.ts
+++ b/packages/app-core/src/rewards-engine/simple-calculator.ts
@@ -110,8 +110,8 @@ export class SimpleRewardsCalculator {
   /**
    * Calculate the current period for a card based on billing cycle
    */
-  static calculatePeriod(card: CreditCard): CalculationPeriod {
-    const period = calculateCardPeriod(card);
+  static calculatePeriod(card: CreditCard, targetDate: Date = new Date()): CalculationPeriod {
+    const period = calculateCardPeriod(card, targetDate);
     const useStartLabel = Boolean(card.billingCycle?.type === 'billing' && card.billingCycle.dayOfMonth);
 
     return toSimplePeriod(period, useStartLabel);


### PR DESCRIPTION
## What changed
- adds dashboard rewind controls so the featured dashboard can be viewed as of a selected historical date
- supports stepping backward and forward by day or month, plus direct date selection from a popover
- threads the selected as-of date through dashboard transaction loading and card reward summaries so historical snapshots are calculated correctly
- keeps live-only behaviours, such as hidden-card actions, restricted to the actual current-day view

## Why this changed
The dashboard only showed the current period, which made it hard to inspect last month's totals or rewind further when checking rewards progress and historical spend.

## Impact
- users can review dashboard rewards history without leaving the main dashboard
- billing-cycle cards now show a true as-of snapshot instead of only today's state
- desktop and mobile header controls stay compact while exposing the rewind controls on demand

## Root cause
The dashboard calculations and fetch window were anchored to the current date only, and the header had no way to move that reference date backward.

## Validation
- `pnpm -C apps/web test -- dashboard-period`
- `pnpm -C apps/web typecheck`
