### PR TITLE
[codex] Update YNAB API plan endpoints

### DIFF
--- a/apps/web/app/api/ynab/budgets/route.ts
+++ b/apps/web/app/api/ynab/budgets/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
   } catch (error) {
     console.error('Proxy error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch budgets' },
+      { error: 'Failed to fetch YNAB plans' },
       { status: 500 }
     );
   }

--- a/apps/web/app/api/ynab/budgets/route.ts
+++ b/apps/web/app/api/ynab/budgets/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
   const token = authHeader.substring(7); // Remove "Bearer " prefix
 
   try {
-    const response = await fetch(`${YNAB_API_BASE}/budgets`, {
+    const response = await fetch(`${YNAB_API_BASE}/plans`, {
       headers: {
         'Authorization': `Bearer ${token}`,
         'Accept': 'application/json',

--- a/apps/web/app/recommendations/page.tsx
+++ b/apps/web/app/recommendations/page.tsx
@@ -83,7 +83,7 @@ export default function RecommendationsPage() {
       const sinceDate = getEarliestPeriodStart(cards);
 
       const response = await fetch(
-        `/api/ynab/budgets/${selectedBudget.id}/transactions?since_date=${sinceDate}`,
+        `/api/ynab/plans/${selectedBudget.id}/transactions?since_date=${sinceDate}`,
         {
           headers: {
             'Authorization': `Bearer ${pat}`,

--- a/apps/web/components/transactions/EnhancedTransactionsTable.tsx
+++ b/apps/web/components/transactions/EnhancedTransactionsTable.tsx
@@ -225,7 +225,7 @@ export function EnhancedTransactionsTable({
 
       try {
         const response = await fetch(
-          `/api/ynab/budgets/${selectedBudgetId}/transactions/${transactionId}`,
+          `/api/ynab/plans/${selectedBudgetId}/transactions/${transactionId}`,
           {
             method: "PATCH",
             headers: {

--- a/apps/web/lib/ynab-client.test.ts
+++ b/apps/web/lib/ynab-client.test.ts
@@ -110,4 +110,32 @@ describe("YnabClient cache bypass", () => {
 
     await expect(client.getBudgets()).rejects.toThrow("invalid token");
   });
+
+  it("throws when the plans response shape is unexpected", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { default_plan: null } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new YnabClient("pat-plans");
+
+    await expect(client.getBudgets()).rejects.toThrow(
+      "Unexpected YNAB plans response: missing plans array",
+    );
+  });
+
+  it("throws when the plan response shape is unexpected", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { server_knowledge: 1 } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new YnabClient("pat-plan");
+
+    await expect(client.getBudget("budget-1")).rejects.toThrow(
+      "Unexpected YNAB plan response: missing plan object",
+    );
+  });
 });

--- a/apps/web/lib/ynab-client.test.ts
+++ b/apps/web/lib/ynab-client.test.ts
@@ -69,6 +69,10 @@ describe("YnabClient cache bypass", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/ynab/plans/budget-1/transactions?since_date=2026-04-01",
+      expect.any(Object),
+    );
   });
 
   it("skips the persisted account cache when bypassCache is set", async () => {
@@ -87,6 +91,10 @@ describe("YnabClient cache bypass", () => {
     await client.getAccounts("budget-2", { bypassCache: true });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/ynab/plans/budget-2/accounts",
+      expect.any(Object),
+    );
   });
 
   it("preserves JSON error messages from the YNAB proxy", async () => {

--- a/apps/web/lib/ynab-client.ts
+++ b/apps/web/lib/ynab-client.ts
@@ -104,6 +104,30 @@ interface YnabResponse<T> {
   data: T;
 }
 
+function extractPlans(data: { plans?: YnabBudgetSummary[]; budgets?: YnabBudgetSummary[] }) {
+  if (Array.isArray(data.plans)) {
+    return data.plans;
+  }
+
+  if (Array.isArray(data.budgets)) {
+    return data.budgets;
+  }
+
+  throw new Error("Unexpected YNAB plans response: missing plans array");
+}
+
+function extractPlan(data: { plan?: unknown; budget?: unknown }) {
+  if ("plan" in data) {
+    return data.plan;
+  }
+
+  if ("budget" in data) {
+    return data.budget;
+  }
+
+  throw new Error("Unexpected YNAB plan response: missing plan object");
+}
+
 interface YnabRequestOptions extends RequestInit {
   bypassCache?: boolean;
 }
@@ -200,7 +224,7 @@ export class YnabClient {
     const result = await this.request<
       YnabResponse<{ plans?: YnabBudgetSummary[]; budgets?: YnabBudgetSummary[] }>
     >("plans", init);
-    return result.data.plans ?? result.data.budgets ?? [];
+    return extractPlans(result.data);
   }
 
   async getBudget(budgetId: string, init?: YnabRequestOptions) {
@@ -210,7 +234,7 @@ export class YnabClient {
       `plans/${budgetId}`,
       init,
     );
-    return result.data.plan ?? result.data.budget ?? null;
+    return extractPlan(result.data);
   }
 
   // Accounts

--- a/apps/web/lib/ynab-client.ts
+++ b/apps/web/lib/ynab-client.ts
@@ -198,17 +198,19 @@ export class YnabClient {
   // Budgets
   async getBudgets(init?: YnabRequestOptions) {
     const result = await this.request<
-      YnabResponse<{ budgets: YnabBudgetSummary[] }>
-    >("budgets", init);
-    return result.data.budgets;
+      YnabResponse<{ plans?: YnabBudgetSummary[]; budgets?: YnabBudgetSummary[] }>
+    >("plans", init);
+    return result.data.plans ?? result.data.budgets ?? [];
   }
 
   async getBudget(budgetId: string, init?: YnabRequestOptions) {
-    const result = await this.request<YnabResponse<{ budget: unknown }>>(
-      `budgets/${budgetId}`,
+    const result = await this.request<
+      YnabResponse<{ plan?: unknown; budget?: unknown }>
+    >(
+      `plans/${budgetId}`,
       init,
     );
-    return result.data.budget;
+    return result.data.plan ?? result.data.budget ?? null;
   }
 
   // Accounts
@@ -230,7 +232,7 @@ export class YnabClient {
     }
 
     const result = await this.request<YnabResponse<{ accounts: TAccount[] }>>(
-      `budgets/${budgetId}/accounts`,
+      `plans/${budgetId}/accounts`,
       init,
     );
     storage.setBudgetAccountsCache(
@@ -245,7 +247,7 @@ export class YnabClient {
   async getBudgetSettings(budgetId: string, init?: YnabRequestOptions) {
     const result = await this.request<
       YnabResponse<{ settings: Record<string, unknown> }>
-    >(`budgets/${budgetId}/settings`, init);
+    >(`plans/${budgetId}/settings`, init);
     return result.data.settings;
   }
 
@@ -336,7 +338,7 @@ export class YnabClient {
   async getCategories(budgetId: string, init?: YnabRequestOptions) {
     const result = await this.request<
       YnabResponse<{ category_groups: unknown }>
-    >(`budgets/${budgetId}/categories`, init);
+    >(`plans/${budgetId}/categories`, init);
     return result.data.category_groups;
   }
 
@@ -357,7 +359,7 @@ export class YnabClient {
     const query = params.toString() ? `?${params.toString()}` : "";
     const result = await this.request<
       YnabResponse<{ transactions: Transaction[] }>
-    >(`budgets/${budgetId}/transactions${query}`, {
+    >(`plans/${budgetId}/transactions${query}`, {
       signal: options?.signal,
       bypassCache: options?.bypassCache,
     });
@@ -371,14 +373,14 @@ export class YnabClient {
   ) {
     const result = await this.request<
       YnabResponse<{ transaction: Transaction }>
-    >(`budgets/${budgetId}/transactions/${transactionId}`, init);
+    >(`plans/${budgetId}/transactions/${transactionId}`, init);
     return result.data.transaction;
   }
 
   // Payees
   async getPayees(budgetId: string, init?: YnabRequestOptions) {
     const result = await this.request<YnabResponse<{ payees: YnabPayee[] }>>(
-      `budgets/${budgetId}/payees`,
+      `plans/${budgetId}/payees`,
       init,
     );
     return result.data.payees;

--- a/packages/ynab-client/src/client.test.ts
+++ b/packages/ynab-client/src/client.test.ts
@@ -73,4 +73,21 @@ describe('YnabClient', () => {
       },
     ]);
   });
+
+  it('throws when the plans response shape is unexpected', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { default_plan: null } }),
+    });
+
+    const client = new YnabClient({
+      accessToken: 'test-token',
+      fetchImpl,
+    });
+
+    await expect(client.getBudgets()).rejects.toThrow(
+      'Unexpected YNAB plans response: missing plans array',
+    );
+  });
 });

--- a/packages/ynab-client/src/client.test.ts
+++ b/packages/ynab-client/src/client.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { YnabClient } from './client';
+
+describe('YnabClient', () => {
+  it('uses YNAB plans endpoints while preserving budget-facing methods', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { plans: [] } }),
+    });
+
+    const client = new YnabClient({
+      accessToken: 'test-token',
+      fetchImpl,
+    });
+
+    await client.getBudgets();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.ynab.com/v1/plans',
+      expect.any(Object),
+    );
+  });
+
+  it('uses plans paths for plan-scoped resources', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { accounts: [] } }),
+    });
+
+    const client = new YnabClient({
+      accessToken: 'test-token',
+      fetchImpl,
+    });
+
+    await client.getAccounts('plan-1', { lastKnowledgeOfServer: 42 });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.ynab.com/v1/plans/plan-1/accounts?last_knowledge_of_server=42',
+      expect.any(Object),
+    );
+  });
+
+  it('accepts legacy budget response keys for compatibility', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          budgets: [
+            {
+              id: 'budget-1',
+              name: 'Legacy Budget',
+              last_modified_on: '2026-01-01T00:00:00Z',
+            },
+          ],
+        },
+      }),
+    });
+
+    const client = new YnabClient({
+      accessToken: 'test-token',
+      fetchImpl,
+    });
+
+    await expect(client.getBudgets()).resolves.toEqual([
+      {
+        id: 'budget-1',
+        name: 'Legacy Budget',
+        last_modified_on: '2026-01-01T00:00:00Z',
+      },
+    ]);
+  });
+});

--- a/packages/ynab-client/src/client.ts
+++ b/packages/ynab-client/src/client.ts
@@ -64,21 +64,26 @@ export class YnabClient {
   }
 
   /**
-   * Get all budgets for the authenticated user.
+   * Get all plans for the authenticated user.
+   *
+   * The method keeps the app's existing "budget" terminology stable while
+   * using YNAB's current /plans API on the wire.
    */
   async getBudgets(options?: { signal?: AbortSignal }): Promise<YnabBudgetSummary[]> {
-    const response = await this.request<YnabApiResponse<{ budgets: YnabBudgetSummary[] }>>(
-      '/budgets',
+    const response = await this.request<
+      YnabApiResponse<{ plans?: YnabBudgetSummary[]; budgets?: YnabBudgetSummary[] }>
+    >(
+      '/plans',
       options,
     );
-    return response.data.budgets;
+    return response.data.plans ?? response.data.budgets ?? [];
   }
 
   /**
-   * Get all accounts for a budget.
+   * Get all accounts for a plan.
    */
   async getAccounts(budgetId: string, options?: ListOptions): Promise<YnabAccountSummary[]> {
-    const path = buildPath(`/budgets/${budgetId}/accounts`, options);
+    const path = buildPath(`/plans/${budgetId}/accounts`, options);
     const response = await this.request<YnabApiResponse<{ accounts: YnabAccountSummary[] }>>(
       path,
       options,
@@ -87,10 +92,10 @@ export class YnabClient {
   }
 
   /**
-   * Get all category groups and categories for a budget.
+   * Get all category groups and categories for a plan.
    */
   async getCategories(budgetId: string, options?: ListOptions): Promise<YnabCategoryGroup[]> {
-    const path = buildPath(`/budgets/${budgetId}/categories`, options);
+    const path = buildPath(`/plans/${budgetId}/categories`, options);
     const response = await this.request<YnabApiResponse<{ category_groups: YnabCategoryGroup[] }>>(
       path,
       options,
@@ -99,10 +104,10 @@ export class YnabClient {
   }
 
   /**
-   * Get all payees for a budget.
+   * Get all payees for a plan.
    */
   async getPayees(budgetId: string, options?: ListOptions): Promise<YnabPayee[]> {
-    const path = buildPath(`/budgets/${budgetId}/payees`, options);
+    const path = buildPath(`/plans/${budgetId}/payees`, options);
     const response = await this.request<YnabApiResponse<{ payees: YnabPayee[] }>>(
       path,
       options,
@@ -111,7 +116,7 @@ export class YnabClient {
   }
 
   /**
-   * Get transactions for a budget, optionally filtered.
+   * Get transactions for a plan, optionally filtered.
    */
   async getTransactions(
     budgetId: string,
@@ -195,6 +200,6 @@ function buildTransactionsPath(budgetId: string, options?: TransactionFilterOpti
   }
 
   const query = params.toString();
-  const basePath = `/budgets/${budgetId}/transactions`;
+  const basePath = `/plans/${budgetId}/transactions`;
   return query ? `${basePath}?${query}` : basePath;
 }

--- a/packages/ynab-client/src/client.ts
+++ b/packages/ynab-client/src/client.ts
@@ -76,7 +76,7 @@ export class YnabClient {
       '/plans',
       options,
     );
-    return response.data.plans ?? response.data.budgets ?? [];
+    return extractPlans(response.data);
   }
 
   /**
@@ -165,6 +165,18 @@ export class YnabClient {
       signal: options?.signal,
     });
   }
+}
+
+function extractPlans(data: { plans?: YnabBudgetSummary[]; budgets?: YnabBudgetSummary[] }): YnabBudgetSummary[] {
+  if (Array.isArray(data.plans)) {
+    return data.plans;
+  }
+
+  if (Array.isArray(data.budgets)) {
+    return data.budgets;
+  }
+
+  throw new Error('Unexpected YNAB plans response: missing plans array');
 }
 
 /**

--- a/packages/ynab-client/src/index.ts
+++ b/packages/ynab-client/src/index.ts
@@ -23,6 +23,7 @@ export type { RequestOptions } from './request';
 // DTO types
 export type {
   YnabApiResponse,
+  YnabPlanSummary,
   YnabBudgetSummary,
   YnabAccountSummary,
   YnabPayee,

--- a/packages/ynab-client/src/request.test.ts
+++ b/packages/ynab-client/src/request.test.ts
@@ -19,7 +19,7 @@ describe('defaultBackoff', () => {
 describe('requestJson', () => {
   const mockFetch = vi.fn();
   const defaultOptions = {
-    path: '/budgets',
+    path: '/plans',
     accessToken: 'test-token',
     fetchImpl: mockFetch,
   };
@@ -35,7 +35,7 @@ describe('requestJson', () => {
 
   describe('successful requests', () => {
     it('returns parsed JSON on success', async () => {
-      const mockData = { data: { budgets: [] } };
+      const mockData = { data: { plans: [] } };
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -50,7 +50,7 @@ describe('requestJson', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({ data: { budgets: [] } }),
+        json: () => Promise.resolve({ data: { plans: [] } }),
       });
 
       await requestJson({
@@ -71,7 +71,7 @@ describe('requestJson', () => {
       await requestJson(defaultOptions);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.ynab.com/v1/budgets',
+        'https://api.ynab.com/v1/plans',
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test-token',

--- a/packages/ynab-client/src/request.ts
+++ b/packages/ynab-client/src/request.ts
@@ -8,7 +8,7 @@ import type { YnabApiErrorCode } from './errors';
 export const DEFAULT_BASE_URL = 'https://api.ynab.com/v1';
 
 export interface RequestOptions {
-  /** API path (e.g., '/budgets' or '/budgets/{id}/accounts') */
+  /** API path (e.g., '/plans' or '/plans/{id}/accounts') */
   path: string;
   /** YNAB Personal Access Token */
   accessToken: string;

--- a/packages/ynab-client/src/types.ts
+++ b/packages/ynab-client/src/types.ts
@@ -2,7 +2,7 @@
  * YNAB API response types (DTOs)
  */
 
-export interface YnabBudgetSummary {
+export interface YnabPlanSummary {
   id: string;
   name: string;
   last_modified_on: string;
@@ -20,6 +20,8 @@ export interface YnabBudgetSummary {
     display_symbol: boolean;
   };
 }
+
+export type YnabBudgetSummary = YnabPlanSummary;
 
 export interface YnabAccountSummary {
   id: string;
@@ -83,6 +85,7 @@ export interface YnabCategoryGroup {
   id: string;
   name: string;
   hidden: boolean;
+  internal?: boolean;
   deleted?: boolean;
   categories: YnabCategory[];
 }
@@ -93,6 +96,7 @@ export interface YnabCategory {
   category_group_name?: string;
   name: string;
   hidden: boolean;
+  internal?: boolean;
   original_category_group_id?: string | null;
   note?: string | null;
   budgeted?: number;


### PR DESCRIPTION
## Summary

Updates the YNAB integration to use the current `/v1/plans` API paths while keeping the app-facing budget terminology stable.

## What changed

- Switched shared and web YNAB clients from `/budgets` paths to `/plans` paths.
- Added parsing for current `plans`/`plan` response keys with compatibility fallback for legacy `budgets`/`budget` keys.
- Updated direct web proxy fetches for transactions and flag updates to use `/api/ynab/plans/...`.
- Added `YnabPlanSummary` plus newer category `internal` fields.
- Added tests that assert the client uses `/plans` endpoints.

## Why

YNAB's current API documentation and changelog describe plans as the canonical resource. The previous `/budgets` paths are backward-compatible but no longer the latest documented API surface.

## Validation

- `pnpm --filter @ynab-counter/ynab-client test`
- `pnpm --filter ./apps/web test -- ynab-client.test.ts`
- `pnpm typecheck`
- `pnpm --filter ./apps/mobile typecheck`
- `pnpm lint` (passes with existing unrelated warnings)
- Live throwaway PAT check against:
  - `GET /v1/plans`
  - `GET /v1/plans/{id}/accounts`
  - `GET /v1/plans/{id}/transactions?since_date=2026-05-01`
  - `GET /v1/plans/{id}/settings`