### PR TITLE
[codex] Fix PAT replacement and cloud restore setup state

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -201,6 +201,7 @@ export default function SettingsPage() {
   const [showClearDialog, setShowClearDialog] = useState(false);
   const [showClearTokenDialog, setShowClearTokenDialog] = useState(false);
   const hasRequestedBudgetsRef = useRef(false);
+  const skipConnectionFetchForPatRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [cloudSyncPhrase, setCloudSyncPhrase] = useState('');
@@ -436,6 +437,12 @@ export default function SettingsPage() {
   useEffect(() => {
     if (!pat) {
       hasRequestedBudgetsRef.current = false;
+      skipConnectionFetchForPatRef.current = null;
+      return;
+    }
+
+    if (skipConnectionFetchForPatRef.current === pat) {
+      skipConnectionFetchForPatRef.current = null;
       return;
     }
 
@@ -482,6 +489,8 @@ export default function SettingsPage() {
       const client = new YnabClient(nextToken);
       const fetchedBudgets = await client.getBudgets();
       setBudgets(fetchedBudgets);
+      hasRequestedBudgetsRef.current = true;
+      skipConnectionFetchForPatRef.current = nextToken;
 
       const matchingBudget = fetchedBudgets.find((budget) => budget.id === selectedBudget.id);
       if (matchingBudget) {

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -484,11 +484,10 @@ export default function SettingsPage() {
       setBudgets(fetchedBudgets);
 
       const matchingBudget = fetchedBudgets.find((budget) => budget.id === selectedBudget.id);
-      setPAT(nextToken);
-      setTokenInput('');
-
       if (matchingBudget) {
         persistSelectedBudget(matchingBudget.id, matchingBudget.name);
+        setPAT(nextToken);
+        setTokenInput('');
         setConnectionMessage('Token saved! Refreshing selected budget...');
         fetchAccounts(matchingBudget.id, nextToken);
         return;
@@ -498,6 +497,8 @@ export default function SettingsPage() {
       persistTrackedAccountIds([]);
       setAccounts([]);
       setShowBudgetSelector(true);
+      setPAT(nextToken);
+      setTokenInput('');
       setConnectionMessage('Token saved. Select a budget available to this token.');
     } catch (error) {
       setConnectionMessage(`Failed to replace token: ${getErrorMessage(error)}`);

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -454,20 +454,56 @@ export default function SettingsPage() {
 
   async function handleSaveToken(e: React.FormEvent) {
     e.preventDefault();
-    
-    const validation = validateYnabToken(tokenInput);
+
+    const nextToken = tokenInput.trim();
+    const validation = validateYnabToken(nextToken);
     if (!validation.valid) {
       setConnectionMessage(`❌ ${validation.error}`);
       return;
     }
 
-    const nextToken = tokenInput;
+    if (selectedBudget.id) {
+      await handleReplaceToken(nextToken);
+      return;
+    }
+
     setPAT(nextToken);
     setConnectionMessage('Token saved! Fetching budgets...');
     setTokenInput('');
-    
-    // Immediately fetch budgets after saving token
+
     fetchBudgets(nextToken);
+  }
+
+  async function handleReplaceToken(nextToken: string) {
+    setLoadingBudgets(true);
+    setConnectionMessage('Checking access to your selected budget...');
+
+    try {
+      const client = new YnabClient(nextToken);
+      const fetchedBudgets = await client.getBudgets();
+      setBudgets(fetchedBudgets);
+
+      const matchingBudget = fetchedBudgets.find((budget) => budget.id === selectedBudget.id);
+      setPAT(nextToken);
+      setTokenInput('');
+
+      if (matchingBudget) {
+        persistSelectedBudget(matchingBudget.id, matchingBudget.name);
+        setConnectionMessage('Token saved! Refreshing selected budget...');
+        fetchAccounts(matchingBudget.id, nextToken);
+        return;
+      }
+
+      persistSelectedBudget('', '');
+      persistTrackedAccountIds([]);
+      setAccounts([]);
+      setShowBudgetSelector(true);
+      setConnectionMessage('Token saved. Select a budget available to this token.');
+    } catch (error) {
+      setConnectionMessage(`Failed to replace token: ${getErrorMessage(error)}`);
+    } finally {
+      setLoadingBudgets(false);
+    }
   }
 
   function handleAccountToggle(accountId: string, accountName: string) {
@@ -1081,6 +1117,25 @@ export default function SettingsPage() {
                   <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
                   <span className="font-medium">Token configured</span>
                 </div>
+
+                <form onSubmit={handleSaveToken} className="space-y-2 rounded-lg border bg-muted/20 p-3">
+                  <label className="text-sm font-medium" htmlFor="replace-token-input">
+                    Replace token
+                  </label>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <input
+                      id="replace-token-input"
+                      type="password"
+                      value={tokenInput}
+                      onChange={(e) => setTokenInput(e.target.value)}
+                      placeholder="Paste a new YNAB Personal Access Token"
+                      className="flex-1 px-3 py-2 border rounded-md text-base md:text-sm"
+                    />
+                    <Button type="submit" disabled={!tokenInput.trim()}>
+                      Replace Token
+                    </Button>
+                  </div>
+                </form>
 
                 {/* Budget Selection */}
                 {selectedBudget.id && !showBudgetSelector ? (

--- a/apps/web/lib/storage/service.test.ts
+++ b/apps/web/lib/storage/service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { StorageService } from "./service";
+import type { CreditCard } from "./types";
 
 type LocalStorageMock = {
   getItem(key: string): string | null;
@@ -91,5 +92,130 @@ describe("StorageService budget accounts cache", () => {
     expect(() => service.updateSettings({ currency: "SGD" })).toThrow(
       "Quota exceeded",
     );
+  });
+});
+
+describe("StorageService importSettings", () => {
+  beforeEach(() => {
+    const localStorageMock = createLocalStorageMock();
+
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    Object.defineProperty(globalThis, "localStorage", {
+      value: localStorageMock,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  const importedBase = {
+    cards: [],
+    rules: [],
+    tagMappings: [],
+    calculations: [],
+    themeGroups: [],
+    settings: {
+      theme: "dark",
+    },
+  };
+
+  function buildCard(accountId: string): CreditCard {
+    return {
+      id: `card-${accountId}`,
+      name: "Rewards Card",
+      issuer: "Bank",
+      type: "cashback",
+      ynabAccountId: accountId,
+      featured: true,
+      earningRate: 1,
+    };
+  }
+
+  it("preserves the local PAT, budget, and tracked accounts when a cloud payload has no YNAB selection", () => {
+    const service = new StorageService();
+
+    service.setPAT("local-pat");
+    service.setSelectedBudget("budget-local", "Local Budget");
+    service.setTrackedAccountIds(["account-local"]);
+
+    service.importSettings(JSON.stringify({ ...importedBase, ynab: {} }));
+
+    expect(service.getPAT()).toBe("local-pat");
+    expect(service.getSelectedBudget()).toEqual({
+      id: "budget-local",
+      name: "Local Budget",
+    });
+    expect(service.getTrackedAccountIds()).toEqual(["account-local"]);
+  });
+
+  it("treats empty imported budget fields as absent and reconstructs tracked accounts from imported cards", () => {
+    const service = new StorageService();
+
+    service.setPAT("local-pat");
+    service.setSelectedBudget("budget-local", "Local Budget");
+
+    service.importSettings(
+      JSON.stringify({
+        ...importedBase,
+        ynab: {
+          selectedBudgetId: "",
+          selectedBudgetName: "",
+          trackedAccountIds: [],
+        },
+        cards: [buildCard("account-card")],
+      }),
+    );
+
+    expect(service.getPAT()).toBe("local-pat");
+    expect(service.getSelectedBudget()).toEqual({
+      id: "budget-local",
+      name: "Local Budget",
+    });
+    expect(service.getTrackedAccountIds()).toEqual(["account-card"]);
+  });
+
+  it("uses valid YNAB connection fields from the imported payload", () => {
+    const service = new StorageService();
+
+    service.setPAT("local-pat");
+    service.setSelectedBudget("budget-local", "Local Budget");
+    service.setTrackedAccountIds(["account-local"]);
+
+    service.importSettings(
+      JSON.stringify({
+        ...importedBase,
+        ynab: {
+          selectedBudgetId: "budget-cloud",
+          selectedBudgetName: "Cloud Budget",
+          trackedAccountIds: ["account-cloud"],
+        },
+      }),
+    );
+
+    expect(service.getPAT()).toBe("local-pat");
+    expect(service.getSelectedBudget()).toEqual({
+      id: "budget-cloud",
+      name: "Cloud Budget",
+    });
+    expect(service.getTrackedAccountIds()).toEqual(["account-cloud"]);
+  });
+
+  it("removes stored budget fields when setSelectedBudget is called with an empty value", () => {
+    const service = new StorageService();
+
+    service.setSelectedBudget("budget-local", "Local Budget");
+    service.setSelectedBudget("", "");
+
+    expect(service.getSelectedBudget()).toEqual({
+      id: undefined,
+      name: undefined,
+    });
   });
 });

--- a/apps/web/lib/storage/service.test.ts
+++ b/apps/web/lib/storage/service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { STORAGE_KEY } from "@ynab-counter/app-core/storage";
 
 import { StorageService } from "./service";
 import type { CreditCard } from "./types";
@@ -27,6 +28,15 @@ function createLocalStorageMock(): LocalStorageMock {
       store.clear();
     },
   };
+}
+
+function readStoredYnab(): Record<string, unknown> {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    throw new Error("Expected storage to be populated");
+  }
+
+  return JSON.parse(stored).ynab;
 }
 
 describe("StorageService budget accounts cache", () => {
@@ -155,6 +165,43 @@ describe("StorageService importSettings", () => {
     expect(service.getTrackedAccountIds()).toEqual(["account-local"]);
   });
 
+  it("preserves local YNAB metadata when importing partial connection settings", () => {
+    const service = new StorageService();
+
+    service.setPAT("local-pat");
+    service.setSelectedBudget("budget-local", "Local Budget");
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      throw new Error("Expected storage to be populated");
+    }
+
+    const storage = JSON.parse(stored);
+    storage.ynab.lastSync = "2026-05-22T01:02:03.000Z";
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(storage));
+
+    new StorageService().importSettings(JSON.stringify({ ...importedBase, ynab: {} }));
+
+    expect(readStoredYnab().lastSync).toBe("2026-05-22T01:02:03.000Z");
+  });
+
+  it("ignores array-shaped imported YNAB settings", () => {
+    const service = new StorageService();
+
+    service.setPAT("local-pat");
+    service.setSelectedBudget("budget-local", "Local Budget");
+    service.setTrackedAccountIds(["account-local"]);
+
+    service.importSettings(JSON.stringify({ ...importedBase, ynab: [] }));
+
+    expect(service.getPAT()).toBe("local-pat");
+    expect(service.getSelectedBudget()).toEqual({
+      id: "budget-local",
+      name: "Local Budget",
+    });
+    expect(service.getTrackedAccountIds()).toEqual(["account-local"]);
+  });
+
   it("treats empty imported budget fields as absent and reconstructs tracked accounts from imported cards", () => {
     const service = new StorageService();
 
@@ -205,6 +252,29 @@ describe("StorageService importSettings", () => {
       name: "Cloud Budget",
     });
     expect(service.getTrackedAccountIds()).toEqual(["account-cloud"]);
+  });
+
+  it("trims imported YNAB budget and tracked account fields", () => {
+    const service = new StorageService();
+
+    service.setPAT("local-pat");
+
+    service.importSettings(
+      JSON.stringify({
+        ...importedBase,
+        ynab: {
+          selectedBudgetId: " budget-cloud ",
+          selectedBudgetName: " Cloud Budget ",
+          trackedAccountIds: [" account-b ", "account-a", "account-a ", "  ", 123],
+        },
+      }),
+    );
+
+    expect(service.getSelectedBudget()).toEqual({
+      id: "budget-cloud",
+      name: "Cloud Budget",
+    });
+    expect(service.getTrackedAccountIds()).toEqual(["account-a", "account-b"]);
   });
 
   it("removes stored budget fields when setSelectedBudget is called with an empty value", () => {

--- a/apps/web/lib/storage/service.ts
+++ b/apps/web/lib/storage/service.ts
@@ -859,9 +859,11 @@ export class StorageService {
     cards: CreditCard[],
   ): YnabConnection {
     const imported =
-      importedYnab && typeof importedYnab === "object" ? importedYnab : {};
+      importedYnab && typeof importedYnab === "object" && !Array.isArray(importedYnab)
+        ? importedYnab
+        : {};
 
-    const next: YnabConnection = { ...imported };
+    const next: YnabConnection = { ...localYnab, ...imported };
     const importedBudgetId = this.nonEmptyString(imported.selectedBudgetId);
     const importedBudgetName = this.nonEmptyString(imported.selectedBudgetName);
     const localBudgetId = this.nonEmptyString(localYnab.selectedBudgetId);
@@ -900,7 +902,12 @@ export class StorageService {
   }
 
   private nonEmptyString(value: unknown): string | undefined {
-    return typeof value === "string" && value.trim() ? value : undefined;
+    if (typeof value !== "string") {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
   }
 
   private normaliseAccountIds(value: unknown): string[] {
@@ -910,10 +917,9 @@ export class StorageService {
 
     return Array.from(
       new Set(
-        value.filter(
-          (entry): entry is string =>
-            typeof entry === "string" && entry.trim().length > 0,
-        ),
+        value
+          .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+          .filter((entry) => entry.length > 0),
       ),
     ).sort();
   }

--- a/apps/web/lib/storage/service.ts
+++ b/apps/web/lib/storage/service.ts
@@ -239,8 +239,13 @@ export class StorageService {
 
   setSelectedBudget(budgetId: string, budgetName: string): void {
     const storage = this.getStorage();
-    storage.ynab.selectedBudgetId = budgetId;
-    storage.ynab.selectedBudgetName = budgetName;
+    if (budgetId && budgetName) {
+      storage.ynab.selectedBudgetId = budgetId;
+      storage.ynab.selectedBudgetName = budgetName;
+    } else {
+      delete storage.ynab.selectedBudgetId;
+      delete storage.ynab.selectedBudgetName;
+    }
     this.setStorage(storage);
   }
 
@@ -801,17 +806,19 @@ export class StorageService {
 
   importSettings(jsonString: string): void {
     try {
-      const imported = JSON.parse(jsonString);
+      const imported = JSON.parse(jsonString) as Partial<MutableStorageData>;
       const storage = this.getStorage() as MutableStorageData;
 
       // Fix #5: Preserve sensitive local-only data (more explicit checks with optional chaining)
-      const pat = storage.ynab.pat;
+      const localYnab = { ...storage.ynab };
+      const pat = localYnab.pat;
       const cloudSyncMnemonic = storage.settings?.cloudSyncMnemonic;
       const rememberCloudSyncCode = storage.settings?.rememberCloudSyncCode;
       const autoSyncEnabled = storage.settings?.autoSyncEnabled;
       const formatterApiKeys = storage.settings?.statementFormatter?.apiKeys;
 
       Object.assign(storage, imported);
+      storage.ynab = this.mergeImportedYnabConnection(imported.ynab, localYnab, storage.cards);
 
       // Restore PAT if it exists (non-empty string)
       if (pat && typeof pat === "string") {
@@ -844,6 +851,71 @@ export class StorageService {
     } catch (error) {
       throw new Error("Invalid settings file");
     }
+  }
+
+  private mergeImportedYnabConnection(
+    importedYnab: Partial<YnabConnection> | undefined,
+    localYnab: YnabConnection,
+    cards: CreditCard[],
+  ): YnabConnection {
+    const imported =
+      importedYnab && typeof importedYnab === "object" ? importedYnab : {};
+
+    const next: YnabConnection = { ...imported };
+    const importedBudgetId = this.nonEmptyString(imported.selectedBudgetId);
+    const importedBudgetName = this.nonEmptyString(imported.selectedBudgetName);
+    const localBudgetId = this.nonEmptyString(localYnab.selectedBudgetId);
+    const localBudgetName = this.nonEmptyString(localYnab.selectedBudgetName);
+
+    if (importedBudgetId && importedBudgetName) {
+      next.selectedBudgetId = importedBudgetId;
+      next.selectedBudgetName = importedBudgetName;
+    } else if (localBudgetId && localBudgetName) {
+      next.selectedBudgetId = localBudgetId;
+      next.selectedBudgetName = localBudgetName;
+    } else {
+      delete next.selectedBudgetId;
+      delete next.selectedBudgetName;
+    }
+
+    const importedTrackedIds = this.normaliseAccountIds(imported.trackedAccountIds);
+    const cardAccountIds = this.normaliseAccountIds(
+      cards.map((card) => card.ynabAccountId),
+    );
+    const localTrackedIds = this.normaliseAccountIds(localYnab.trackedAccountIds);
+    const trackedAccountIds =
+      importedTrackedIds.length > 0
+        ? importedTrackedIds
+        : cardAccountIds.length > 0
+          ? cardAccountIds
+          : localTrackedIds;
+
+    if (trackedAccountIds.length > 0) {
+      next.trackedAccountIds = trackedAccountIds;
+    } else {
+      delete next.trackedAccountIds;
+    }
+
+    return next;
+  }
+
+  private nonEmptyString(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim() ? value : undefined;
+  }
+
+  private normaliseAccountIds(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return Array.from(
+      new Set(
+        value.filter(
+          (entry): entry is string =>
+            typeof entry === "string" && entry.trim().length > 0,
+        ),
+      ),
+    ).sort();
   }
 
   clearAll(): void {


### PR DESCRIPTION
## Summary

Fixes the setup-state regressions around replacing a YNAB PAT and restoring settings from Cloud Sync.

## Root Cause

- Replacing a PAT effectively required using the destructive "Clear Token" path, which cleared budget and tracked-account selection.
- Cloud restore imported the whole `ynab` connection object over local state. Since cloud exports intentionally omit the PAT and may contain missing or empty budget/account fields, restore could wipe the newly configured local budget/tracked accounts.

## Changes

- Adds an explicit **Replace token** form when a PAT is already configured.
- Verifies that the replacement PAT can access the currently selected budget before keeping that budget selected.
- Clears stale budget/tracked-account state and prompts budget selection when the replacement PAT cannot access the old budget.
- Merges imported YNAB connection state so local PAT and valid local selection are preserved when cloud data omits or empties those fields.
- Reconstructs tracked account IDs from imported cards when cloud data has cards but no tracked-account list.
- Ensures `setSelectedBudget('', '')` actually clears stored budget fields.
- Adds regression coverage for the cloud restore edge cases.

## Validation

- `pnpm --filter ./apps/web test`
- `pnpm typecheck`
- Live browser flow with a throwaway YNAB PAT and real Cloudflare KV REST fallback:
  - fresh setup
  - select budget/account
  - save local to cloud
  - clear local state
  - restore cloud to local
  - replace PAT
  - confirm dashboard no longer shows setup incomplete
  - delete temporary KV entry

## Review

- Copilot review requested.