### PR TITLE
Move card details navigation into the 3-dot menu

### DIFF
--- a/apps/web/components/dashboard/DashboardCardTile.tsx
+++ b/apps/web/components/dashboard/DashboardCardTile.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import type { KeyboardEvent, ReactNode } from "react";
-import { useCallback, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
 import {
   DollarSign,
   EyeOff,
@@ -58,7 +56,6 @@ export interface DashboardCardTileProps {
   prefetchedTransactions: Transaction[];
   onToggleSummarySubcategories(cardId: string): void;
   onHideCard(cardId: string, hiddenUntil: string): void;
-  isSorting?: boolean;
   isDragging?: boolean;
   isRefreshing: boolean;
   showTypeBadge?: boolean;
@@ -77,52 +74,14 @@ export function DashboardCardTile({
   prefetchedTransactions,
   onToggleSummarySubcategories,
   onHideCard,
-  isSorting = false,
   isDragging = false,
   isRefreshing,
   referenceDate,
   allowHideCard,
   dragHandle,
 }: DashboardCardTileProps) {
-  const suppressClickRef = useRef(false);
-  const router = useRouter();
-
-  const handleNavigate = useCallback(() => {
-    router.push(`/cards/${card.id}`);
-  }, [router, card.id]);
-
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        if (!suppressClickRef.current) {
-          handleNavigate();
-        }
-      }
-    },
-    [handleNavigate],
-  );
-
-  useEffect(() => {
-    if (isSorting) {
-      suppressClickRef.current = true;
-      return;
-    }
-
-    if (typeof window === "undefined") {
-      suppressClickRef.current = false;
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      suppressClickRef.current = false;
-    }, 150);
-
-    return () => window.clearTimeout(timeout);
-  }, [isSorting]);
-
   const accentClasses =
-    "border border-border/70 dark:border-border/50 hover:border-primary/40";
+    "border border-border/70 dark:border-border/50";
   const isSubcategoryExpanded = isExpansionMap(summaryViewSubcategoriesExpanded)
     ? (summaryViewSubcategoriesExpanded[card.id] ?? false)
     : Boolean(summaryViewSubcategoriesExpanded);
@@ -150,22 +109,13 @@ export function DashboardCardTile({
 
   return (
     <Card
-      role="link"
-      tabIndex={0}
-      aria-label={`View details for ${card.name}`}
       className={cn(
-        "group relative overflow-hidden flex flex-col h-full cursor-pointer transition-all hover:-translate-y-0.5 hover:shadow-lg",
+        "group relative overflow-hidden flex flex-col h-full",
         "bg-card",
         accentClasses,
         exceeded ? "ring-2 ring-red-300/70 dark:ring-red-900/60" : undefined,
         isDragging ? "ring-2 ring-primary/60 shadow-lg" : undefined,
       )}
-      onClick={() => {
-        if (!suppressClickRef.current) {
-          handleNavigate();
-        }
-      }}
-      onKeyDown={handleKeyDown}
     >
       <div className="absolute top-0 right-0 z-20">
         <DropdownMenu>
@@ -215,7 +165,7 @@ export function DashboardCardTile({
               }}
             >
               <ReceiptText className="h-4 w-4 mr-2" />
-              View transactions
+              View card details
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/web/components/dashboard/DashboardCardTile.tsx
+++ b/apps/web/components/dashboard/DashboardCardTile.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import {
   DollarSign,
@@ -80,6 +81,7 @@ export function DashboardCardTile({
   allowHideCard,
   dragHandle,
 }: DashboardCardTileProps) {
+  const router = useRouter();
   const accentClasses =
     "border border-border/70 dark:border-border/50";
   const isSubcategoryExpanded = isExpansionMap(summaryViewSubcategoriesExpanded)
@@ -139,7 +141,7 @@ export function DashboardCardTile({
           >
             <DropdownMenuItem
               onClick={() => {
-                window.location.href = `/cards/${card.id}?tab=settings&edit=1`;
+                router.push(`/cards/${card.id}?tab=settings&edit=1`);
               }}
             >
               <Settings2 className="h-4 w-4 mr-2" />
@@ -161,7 +163,7 @@ export function DashboardCardTile({
             )}
             <DropdownMenuItem
               onClick={() => {
-                window.location.href = `/cards/${card.id}`;
+                router.push(`/cards/${card.id}`);
               }}
             >
               <ReceiptText className="h-4 w-4 mr-2" />

--- a/apps/web/components/dashboard/SortableDashboardCardGrid.tsx
+++ b/apps/web/components/dashboard/SortableDashboardCardGrid.tsx
@@ -71,7 +71,6 @@ export function SortableDashboardCardGrid({
   referenceDate,
   allowHideCard,
 }: SortableDashboardCardGridProps) {
-  const [activeDragId, setActiveDragId] = useState<string | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, {
@@ -128,12 +127,7 @@ export function SortableDashboardCardGrid({
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
-      onDragStart={({ active }) => setActiveDragId(String(active.id))}
-      onDragCancel={() => setActiveDragId(null)}
-      onDragEnd={(event) => {
-        handleDragEnd(event);
-        setActiveDragId(null);
-      }}
+      onDragEnd={handleDragEnd}
     >
       <SortableContext items={orderedIds} strategy={rectSortingStrategy}>
         <div
@@ -166,7 +160,6 @@ export function SortableDashboardCardGrid({
                 prefetchedTransactions={prefetchedTransactions}
                 onToggleSummarySubcategories={onToggleSummarySubcategories}
                 onHideCard={onHideCard}
-                isSorting={Boolean(activeDragId)}
                 isRefreshing={isRefreshing}
                 showTypeBadge={showTypeBadge}
                 referenceDate={referenceDate}
@@ -191,7 +184,6 @@ interface SortableDashboardCardProps {
   prefetchedTransactions: Transaction[];
   onToggleSummarySubcategories(cardId: string): void;
   onHideCard(cardId: string, hiddenUntil: string): void;
-  isSorting: boolean;
   isRefreshing: boolean;
   showTypeBadge?: boolean;
   referenceDate?: Date;
@@ -209,7 +201,6 @@ function SortableDashboardCard({
   prefetchedTransactions,
   onToggleSummarySubcategories,
   onHideCard,
-  isSorting,
   isRefreshing,
   showTypeBadge = false,
   referenceDate,
@@ -249,7 +240,6 @@ function SortableDashboardCard({
         prefetchedTransactions={prefetchedTransactions}
         onToggleSummarySubcategories={onToggleSummarySubcategories}
         onHideCard={onHideCard}
-        isSorting={isSorting}
         isDragging={isDragging}
         isRefreshing={isRefreshing}
         showTypeBadge={showTypeBadge}


### PR DESCRIPTION
## Summary

- Dashboard card tiles no longer navigate to the card details page when the whole card is clicked; the 3-dot menu's "View card details" item (renamed from "View transactions") is now the sole way in.
- Menu items use `router.push` instead of `window.location.href`, so navigation stays client-side and feels as snappy as the old card tap.
- Cleans up the drag-suppress click plumbing (`isSorting`, `activeDragId`, `suppressClickRef`) that only existed to prevent stray clicks during drag — no longer needed now that the card surface isn't clickable.

## Behaviour

Before: tapping anywhere on a card on the dashboard navigated to `/cards/[id]`.
After: tapping the card does nothing; users open the menu (⋯) → **View card details** to reach the details page. **Edit settings** and **Hide from dashboard** are unchanged.

## Test plan

- [ ] Open `/` with at least one card. Click the body of a card — confirm no navigation occurs.
- [ ] Open the 3-dot menu → **View card details** — confirm soft-nav to `/cards/[id]`.
- [ ] Open the 3-dot menu → **Edit settings** — confirm soft-nav to `/cards/[id]?tab=settings&edit=1`.
- [ ] Drag a card to reorder — confirm reorder still works and no stray navigation triggers.
- [ ] Hide a card via the menu — confirm it disappears until the next billing period.
- [ ] Keyboard: Tab to a card. Confirm the wrapper itself is no longer focusable as a link; the menu and drag handle still receive focus.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4dbgZSmUoDwLsT7YbVdcD)_