### PR TITLE
Clean up card detail page layout

### DIFF
--- a/apps/web/app/cards/[id]/CardSettings.tsx
+++ b/apps/web/app/cards/[id]/CardSettings.tsx
@@ -333,10 +333,6 @@ export default function CardSettings({ card, onUpdate, initialEditing = false }:
                       <div
                         key={subcategory.id}
                         className="flex items-center justify-between gap-4 rounded-lg border border-border/40 bg-muted/10 p-3 overflow-hidden"
-                        style={{
-                          borderLeftWidth: '3px',
-                          borderLeftColor: isExcluded ? '#f97316' : flagColor,
-                        }}
                       >
                         <div className="flex flex-1 items-center gap-3">
                           <div className="flex items-center gap-2">

--- a/apps/web/app/cards/[id]/TransactionsPreview.tsx
+++ b/apps/web/app/cards/[id]/TransactionsPreview.tsx
@@ -3,13 +3,7 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Calendar } from "lucide-react";
 import type { CreditCard } from "@/lib/storage";
@@ -70,20 +64,12 @@ export default function TransactionsPreview({
 
   return (
     <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle>Recent Transactions</CardTitle>
-            <CardDescription>
-              View your recent card transactions
-            </CardDescription>
-          </div>
+      <CardContent className="pt-6">
+        <div className="mb-4 flex justify-end">
           <Button variant="outline" size="sm" onClick={refresh} disabled={loading}>
             Refresh
           </Button>
         </div>
-      </CardHeader>
-      <CardContent>
         {needSetup ? (
           <div className="text-center py-12 text-muted-foreground">
             <Calendar className="h-12 w-12 mx-auto mb-4" />

--- a/apps/web/app/cards/[id]/page.tsx
+++ b/apps/web/app/cards/[id]/page.tsx
@@ -97,15 +97,17 @@ export default function CardDetailPage() {
       </div>
 
       <Collapsible open={transactionsOpen} onOpenChange={setTransactionsOpen} className="mt-8">
-        <CollapsibleTrigger className="flex items-center gap-2 w-full text-left group">
-          <ChevronDown
-            className={cn(
-              'h-5 w-5 text-muted-foreground transition-transform',
-              !transactionsOpen && '-rotate-90'
-            )}
-          />
-          <h2 className="text-lg font-semibold">Recent Transactions</h2>
-        </CollapsibleTrigger>
+        <h2>
+          <CollapsibleTrigger className="flex items-center gap-2 w-full text-left text-lg font-semibold">
+            <ChevronDown
+              className={cn(
+                'h-5 w-5 text-muted-foreground transition-transform',
+                !transactionsOpen && '-rotate-90'
+              )}
+            />
+            Recent Transactions
+          </CollapsibleTrigger>
+        </h2>
         <CollapsibleContent className="pt-4">
           <TransactionsPreview
             card={card}

--- a/apps/web/app/cards/[id]/page.tsx
+++ b/apps/web/app/cards/[id]/page.tsx
@@ -2,17 +2,16 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
 import { useCreditCards, useYnabPAT } from '@/hooks/useLocalStorage';
-import { Button } from '@/components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
-  ArrowLeft,
-  CreditCard as CreditCardIcon
+  CreditCard as CreditCardIcon,
+  ChevronDown,
 } from 'lucide-react';
 import type { CreditCard } from '@/lib/storage';
 import { SimpleRewardsCalculator } from '@/lib/rewards-engine';
 import { useCardTransactions } from '@/hooks/useCardTransactions';
+import { cn } from '@/lib/utils';
 import TransactionsPreview from './TransactionsPreview';
 import SpendingStatus from './SpendingStatus';
 import CardSettings from './CardSettings';
@@ -24,13 +23,13 @@ export default function CardDetailPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const cardId = params.id as string;
-  const defaultTab = searchParams.get('tab') || 'transactions';
   const startEditing = searchParams.get('edit') === '1' || searchParams.get('edit') === 'true';
-  
+
   const { cards } = useCreditCards();
   const { pat } = useYnabPAT();
-  
+
   const [card, setCard] = useState<CreditCard | null>(null);
+  const [transactionsOpen, setTransactionsOpen] = useState(false);
 
   const sharedSinceDate = useMemo(() => {
     if (!card) return undefined;
@@ -53,7 +52,6 @@ export default function CardDetailPage() {
     if (foundCard) {
       setCard(foundCard);
     } else if (cards.length > 0) {
-      // Card not found, redirect to dashboard
       router.push('/');
     }
   }, [cards, cardId, router]);
@@ -71,29 +69,16 @@ export default function CardDetailPage() {
     );
   }
 
-  // No-op: child component handles its own data fetching
-
   return (
     <div className="max-w-6xl mx-auto p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-8">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" asChild>
-            <Link href="/" aria-label="Back to dashboard">
-              <ArrowLeft className="h-5 w-5" aria-hidden="true" />
-            </Link>
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold">{card.name}</h1>
-            <p className="text-muted-foreground mt-1">
-              {card.type === 'cashback' ? 'Cashback Rewards' : 'Miles Rewards'} •
-              {card.featured ? ' Featured on dashboard' : ' Hidden from dashboard'}
-            </p>
-          </div>
-        </div>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">{card.name}</h1>
+        <p className="text-muted-foreground mt-1">
+          {card.type === 'cashback' ? 'Cashback Rewards' : 'Miles Rewards'} •
+          {card.featured ? ' Featured on dashboard' : ' Hidden from dashboard'}
+        </p>
       </div>
 
-      {/* Primary Spending Status - Most Important */}
       {pat && (
         <SpendingStatus
           card={card}
@@ -103,32 +88,25 @@ export default function CardDetailPage() {
         />
       )}
 
-      {/* Secondary content in tabs */}
-      <Tabs defaultValue={defaultTab} className="mt-8">
-        <TabsList className="grid w-full grid-cols-2 h-12 p-1 bg-muted/50">
-          <TabsTrigger
-            value="settings"
-            className="data-[state=active]:bg-background data-[state=active]:shadow-md data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground font-medium transition-all"
-          >
-            Settings
-          </TabsTrigger>
-          <TabsTrigger
-            value="transactions"
-            className="data-[state=active]:bg-background data-[state=active]:shadow-md data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground font-medium transition-all"
-          >
-            Transactions
-          </TabsTrigger>
-        </TabsList>
+      <div className="mt-8">
+        <CardSettings
+          card={card}
+          onUpdate={(updatedCard) => setCard(updatedCard)}
+          initialEditing={startEditing}
+        />
+      </div>
 
-        <TabsContent value="settings" className="mt-6">
-          <CardSettings
-            card={card}
-            onUpdate={(updatedCard) => setCard(updatedCard)}
-            initialEditing={startEditing}
+      <Collapsible open={transactionsOpen} onOpenChange={setTransactionsOpen} className="mt-8">
+        <CollapsibleTrigger className="flex items-center gap-2 w-full text-left group">
+          <ChevronDown
+            className={cn(
+              'h-5 w-5 text-muted-foreground transition-transform',
+              !transactionsOpen && '-rotate-90'
+            )}
           />
-        </TabsContent>
-
-        <TabsContent value="transactions" className="mt-6">
+          <h2 className="text-lg font-semibold">Recent Transactions</h2>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-4">
           <TransactionsPreview
             card={card}
             lookbackDays={TRANSACTION_LOOKBACK_DAYS}
@@ -138,8 +116,8 @@ export default function CardDetailPage() {
             onRefresh={cardTransactions.refresh}
             connection={cardTransactions.connection}
           />
-        </TabsContent>
-      </Tabs>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -174,7 +174,7 @@ function TrackedAccountCard({ account, isTracked, linkedCard, onToggle }: Tracke
           className="mt-4 w-full justify-center"
           asChild
         >
-          <Link href={`/cards/${linkedCard.id}?tab=settings`} aria-label={`View ${linkedCard.name} details`}>
+          <Link href={`/cards/${linkedCard.id}`} aria-label={`View ${linkedCard.name} details`}>
             View card details
           </Link>
         </Button>

--- a/apps/web/components/CardSubcategoriesEditor.tsx
+++ b/apps/web/components/CardSubcategoriesEditor.tsx
@@ -202,12 +202,6 @@ const SubcategoryItem = memo(function SubcategoryItem({
           : 'border-border/30 bg-muted/30 opacity-60',
         localExcluded && 'ring-1 ring-orange-500/20'
       )}
-      style={{
-        borderLeftWidth: '3px',
-        borderLeftColor: localExcluded
-          ? '#f97316'
-          : (FLAG_COLOR_MAP[subcategory.flagColor] || '#6b7280')
-      }}
     >
       {!isUnflagged && (
         <button

--- a/apps/web/components/dashboard/DashboardCardTile.tsx
+++ b/apps/web/components/dashboard/DashboardCardTile.tsx
@@ -189,7 +189,7 @@ export function DashboardCardTile({
           >
             <DropdownMenuItem
               onClick={() => {
-                window.location.href = `/cards/${card.id}?tab=settings&edit=1`;
+                window.location.href = `/cards/${card.id}?edit=1`;
               }}
             >
               <Settings2 className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary

Tidies the `/cards/[id]` page based on feedback:

- Removes the back-arrow button from the top-left header — the global nav already handles navigation home.
- Drops the Settings/Transactions tabs. Card Settings is now shown inline by default, and Recent Transactions is a collapsible section (collapsed by default) below it.
- Removes the coloured left-rail borders on subcategory rows in both the read-only summary (`CardSettings.tsx`) and the editor (`CardSubcategoriesEditor.tsx`). The flag-coloured dot/swatch beside each row still distinguishes flags.
- Drops the now-redundant `<CardHeader>` from `TransactionsPreview` (the collapsible trigger is the heading) and moves the Refresh button into the card body.
- Updates the dashboard tile and settings page links that used to pass `?tab=settings` — they no longer carry the no-op param.

## Test plan

- [ ] `pnpm --filter ./apps/web typecheck`
- [ ] `pnpm --filter ./apps/web test`
- [ ] Visit `/cards/<id>` and confirm: no back arrow, no tabs, settings visible by default, Recent Transactions collapsed
- [ ] Expand the Recent Transactions section, confirm the Refresh button works
- [ ] Open subcategory list — no coloured left rails, only the small flag-coloured dot
- [ ] Edit a subcategory — same in the editor view
- [ ] Click "Edit settings" on a dashboard card → lands on card page in edit mode
- [ ] On the YNAB settings page, click "View card details" for a tracked card → opens the card detail page

---
_Generated by [Claude Code](https://claude.ai/code/session_01JU74AF7fVyMtWzxvg96hLP)_