### PR TITLE
Harden rewards date handling and progress labels

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -105,8 +105,10 @@ function DashboardContent() {
   }, [dayBoundaryTick]);
 
   // dayBoundaryTick is in the dep array so this re-evaluates at each day rollover.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const currentTime = useMemo(() => Date.now(), [dayBoundaryTick]);
+  const currentTime = useMemo(
+    () => Date.now() + dayBoundaryTick * 0,
+    [dayBoundaryTick]
+  );
   const liveDashboardPeriod = useMemo(
     () => resolveDashboardPeriod(null, null, new Date(currentTime)),
     [currentTime]

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -104,10 +104,9 @@ function DashboardContent() {
     };
   }, [dayBoundaryTick]);
 
-  const currentTime = useMemo(
-    () => Date.now() + dayBoundaryTick * 0,
-    [dayBoundaryTick]
-  );
+  // dayBoundaryTick is in the dep array so this re-evaluates at each day rollover.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const currentTime = useMemo(() => Date.now(), [dayBoundaryTick]);
   const liveDashboardPeriod = useMemo(
     () => resolveDashboardPeriod(null, null, new Date(currentTime)),
     [currentTime]

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1099,6 +1099,12 @@ export default function SettingsPage() {
 
             {!pat ? (
               <form onSubmit={handleSaveToken} className="space-y-4 sm:pl-10">
+                <label
+                  htmlFor="pat-input"
+                  className="block text-sm font-medium"
+                >
+                  Personal Access Token
+                </label>
                 <p className="text-sm text-muted-foreground">
                   Get your Personal Access Token from your{' '}
                   <a
@@ -1112,7 +1118,9 @@ export default function SettingsPage() {
                 </p>
                 <div className="flex flex-col gap-2 sm:flex-row">
                   <input
+                    id="pat-input"
                     type="password"
+                    autoComplete="off"
                     value={tokenInput}
                     onChange={(e) => setTokenInput(e.target.value)}
                     placeholder="Paste your YNAB Personal Access Token"

--- a/apps/web/components/SpendingProgressBar.tsx
+++ b/apps/web/components/SpendingProgressBar.tsx
@@ -142,7 +142,24 @@ export function SpendingProgressBar({
       {/* Progress bar container */}
       <div className="relative">
         {/* Background bar */}
-        <div className="h-3 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-white/15 shadow-inner">
+        <div
+          className="h-3 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-white/15 shadow-inner"
+          role="progressbar"
+          aria-valuenow={Math.round(progressPercent)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={
+            spendingZone === 'exceeded'
+              ? `Spending cap exceeded: ${Math.round(progressPercent)}%`
+              : spendingZone === 'earning'
+                ? hasMaximum
+                  ? `Earning rewards: ${Math.round(progressPercent)}% of cap used`
+                  : `Earning rewards: ${Math.round(progressPercent)}%`
+                : spendingZone === 'pending'
+                  ? `Working towards minimum: ${Math.round(progressPercent)}%`
+                  : `Spending progress: ${Math.round(progressPercent)}%`
+          }
+        >
           {/* Progress fill */}
           <div
             className={cn(

--- a/apps/web/components/SpendingProgressBar.tsx
+++ b/apps/web/components/SpendingProgressBar.tsx
@@ -102,6 +102,19 @@ export function SpendingProgressBar({
   const remainingToMinimum = hasMinimum ? Math.max(0, minimumSpend - spendForMinimum) : 0;
   const remainingToMaximum = hasMaximum ? Math.max(0, maximumSpend - spendForMaximum) : 0;
   const exceededAmount = hasMaximum && spendForMaximum >= maximumSpend ? spendForMaximum - maximumSpend : 0;
+  const roundedProgressPercent = Math.round(progressPercent);
+  const progressAriaLabel =
+    spendingZone === 'exceeded'
+      ? exceededAmount > 0
+        ? `Spending cap exceeded by ${formatDollars(exceededAmount, { currency })}`
+        : 'Spending cap reached'
+      : spendingZone === 'earning'
+        ? hasMaximum
+          ? `Earning rewards: ${roundedProgressPercent}% of cap used`
+          : `Earning rewards: ${roundedProgressPercent}%`
+        : spendingZone === 'pending'
+          ? `Working towards minimum: ${roundedProgressPercent}%`
+          : `Spending progress: ${roundedProgressPercent}%`;
 
   return (
     <div className={cn("space-y-2", className)}>
@@ -145,20 +158,10 @@ export function SpendingProgressBar({
         <div
           className="h-3 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-white/15 shadow-inner"
           role="progressbar"
-          aria-valuenow={Math.round(progressPercent)}
+          aria-valuenow={roundedProgressPercent}
           aria-valuemin={0}
           aria-valuemax={100}
-          aria-label={
-            spendingZone === 'exceeded'
-              ? `Spending cap exceeded: ${Math.round(progressPercent)}%`
-              : spendingZone === 'earning'
-                ? hasMaximum
-                  ? `Earning rewards: ${Math.round(progressPercent)}% of cap used`
-                  : `Earning rewards: ${Math.round(progressPercent)}%`
-                : spendingZone === 'pending'
-                  ? `Working towards minimum: ${Math.round(progressPercent)}%`
-                  : `Spending progress: ${Math.round(progressPercent)}%`
-          }
+          aria-label={progressAriaLabel}
         >
           {/* Progress fill */}
           <div

--- a/apps/web/components/dashboard/DashboardCardTile.tsx
+++ b/apps/web/components/dashboard/DashboardCardTile.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import {
+  AlertCircle,
   DollarSign,
   EyeOff,
   MoreHorizontal,
@@ -200,7 +201,9 @@ export function DashboardCardTile({
               <Badge
                 variant="outline"
                 className="shrink-0 h-5 px-1.5 gap-1 border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+                aria-label="Spending has reached the configured cap for this period"
               >
+                <AlertCircle className="h-3 w-3" aria-hidden="true" />
                 <span className="text-[0.65rem] font-medium">At cap</span>
               </Badge>
             )}

--- a/packages/app-core/src/rewards-engine/calculator.ts
+++ b/packages/app-core/src/rewards-engine/calculator.ts
@@ -9,7 +9,7 @@ import type {
   AppSettings,
   TransactionWithRewards
 } from '../storage/types';
-import { parseYnabDate } from './date-utils';
+import { formatLocalDate } from './date-utils';
 import { calculateCardPeriod, getRecentCardPeriods } from './utils/periods';
 
 export interface CalculationPeriod {
@@ -31,11 +31,13 @@ export class RewardsCalculator {
     // Get valuation rates from settings (default 1 cent per mile/point)
     const milesValuation = settings?.milesValuation || 0.01;
 
-    // Filter transactions to this period
-    const eligibleTransactions = transactions.filter(txn => {
-      const txnDate = parseYnabDate(txn.date);
-      return txnDate >= period.startDate && txnDate <= period.endDate;
-    });
+    // Filter transactions to this period using string comparison on YNAB's
+    // YYYY-MM-DD dates, which is ordering-equivalent to Date comparison.
+    const periodStartStr = formatLocalDate(period.startDate);
+    const periodEndStr = formatLocalDate(period.endDate);
+    const eligibleTransactions = transactions.filter(
+      txn => txn.date >= periodStartStr && txn.date <= periodEndStr,
+    );
 
     // Calculate total spend
     const totalSpend = Math.abs(

--- a/packages/app-core/src/rewards-engine/compute.ts
+++ b/packages/app-core/src/rewards-engine/compute.ts
@@ -54,6 +54,18 @@ export async function computeCurrentPeriod(
     }
   }
 
+  // Pre-index active rules by cardId so each card lookup is O(1) instead of O(rules).
+  const activeRulesByCardId = new Map<string, RewardRule[]>();
+  for (const rule of allRules) {
+    if (!rule.active) continue;
+    const bucket = activeRulesByCardId.get(rule.cardId);
+    if (bucket) {
+      bucket.push(rule);
+    } else {
+      activeRulesByCardId.set(rule.cardId, [rule]);
+    }
+  }
+
   for (let i = 0; i < trackedCards.length; i++) {
     const card = trackedCards[i];
     const period = periods[i];
@@ -72,7 +84,7 @@ export async function computeCurrentPeriod(
       continue;
     }
 
-    const rules = allRules.filter(r => r.cardId === card.id && r.active);
+    const rules = activeRulesByCardId.get(card.id) ?? [];
     if (rules.length === 0 && card.earningRate && card.earningRate > 0) {
       const simpleCalc = SimpleRewardsCalculator.calculateCardRewards(card, forCard, simplePeriod, settings);
       results.push(createRewardCalculationFromSimple(card, simpleCalc));

--- a/packages/app-core/src/rewards-engine/matcher.ts
+++ b/packages/app-core/src/rewards-engine/matcher.ts
@@ -2,15 +2,11 @@
  * Transaction matching utilities for rewards calculation
  */
 
+import { formatLocalDate } from './date-utils';
 import type { Transaction, TransactionWithRewards } from '../storage/types';
 
 function absFromMilli(amount: number): number {
   return Math.abs(amount) / 1000;
-}
-
-function parseYnabDate(dateString: string): Date {
-  const [year, month, day] = dateString.split('-').map(Number);
-  return new Date(year, month - 1, day);
 }
 
 export class TransactionMatcher {
@@ -28,17 +24,18 @@ export class TransactionMatcher {
   }
 
   /**
-   * Filter transactions by date range
+   * Filter transactions by date range. YNAB stores dates as YYYY-MM-DD strings,
+   * which compare lexicographically in the same order as Date objects, so we
+   * convert the bounds once and skip per-transaction Date parsing.
    */
   static filterByDateRange(
     transactions: TransactionWithRewards[],
     startDate: Date,
     endDate: Date
   ): TransactionWithRewards[] {
-    return transactions.filter(txn => {
-      const txnDate = parseYnabDate(txn.date);
-      return txnDate >= startDate && txnDate <= endDate;
-    });
+    const startStr = formatLocalDate(startDate);
+    const endStr = formatLocalDate(endDate);
+    return transactions.filter(txn => txn.date >= startStr && txn.date <= endStr);
   }
 
   /**

--- a/packages/app-core/src/storage/migrations.ts
+++ b/packages/app-core/src/storage/migrations.ts
@@ -1,3 +1,4 @@
+import { formatLocalDate } from '../rewards-engine/date-utils';
 import type {
   MutableCalculation,
   MutableCard,
@@ -54,10 +55,9 @@ export function applyStorageMigrations(data: MutableStorageData): void {
         if (mutableCard.promotionalPeriod && !mutableCard.promotionalPeriod.startDate) {
           const now = new Date();
           const prevMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-          const isoDate = prevMonth.toISOString().split('T')[0];
           mutableCard.promotionalPeriod = {
             ...mutableCard.promotionalPeriod,
-            startDate: isoDate,
+            startDate: formatLocalDate(prevMonth),
           };
         }
         return mutableCard as CreditCard;


### PR DESCRIPTION
## Summary
- Optimise reward period filtering by comparing YNAB local date strings against local formatted period bounds
- Pre-index active reward rules by card for current-period calculations
- Improve progress/cap accessibility labels and PAT input labelling
- Preserve local dates when migrating promotional period start dates

## Validation
- pnpm --filter @ynab-counter/app-core test
- pnpm --filter @ynab-counter/app-core typecheck
- pnpm --filter ./apps/web typecheck
- pnpm lint (0 errors, existing warnings only)
