### PR TITLE
Give each hero amount a directional identity on dashboard tiles

### DIFF
--- a/apps/web/components/CardSummaryCompact.tsx
+++ b/apps/web/components/CardSummaryCompact.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowUpRight, Gauge, OctagonAlert } from "lucide-react";
 import type { YnabFlagColor } from "@/lib/ynab-constants";
 import { formatDateValue } from "@/lib/dashboard-period";
 import { SimpleRewardsCalculator } from "@/lib/rewards-engine";
@@ -93,6 +94,33 @@ export function CardSummaryCompactContent({
     : hasMinimum && !minimumSpendMet
       ? "min-left"
       : "spent";
+
+  // The hero lockup pairs the amount with a directional glyph and a qualifier word so
+  // its meaning is legible without reading the label: a goal to spend into (amber,
+  // rising arrow), headroom to protect (gauge, heats up near the cap), or money
+  // already spent (no glyph — nothing to act on). Goal/headroom amounts are
+  // hypothetical, so they render rounded and a weight lighter than realised spend.
+  const capUrgent = heroVariant === "cap-left" && nearCap;
+  const heroTone =
+    heroVariant === "cap-over"
+      ? "text-red-600 dark:text-red-400"
+      : heroVariant === "min-left" || capUrgent
+        ? "text-amber-600 dark:text-amber-400"
+        : "text-foreground";
+  const heroSuffix = {
+    "min-left": "to go",
+    "cap-left": "left",
+    "cap-over": "over",
+    spent: "spent",
+  }[heroVariant];
+  const heroTitle =
+    heroVariant === "cap-left"
+      ? `${remainingToMaximum.toFixed(2)} left before the cap`
+      : heroVariant === "cap-over"
+        ? `${exceededAmount.toFixed(2)} over the cap`
+        : heroVariant === "min-left"
+          ? `${remainingToMinimum.toFixed(2)} more to meet the minimum`
+          : `Spent ${displayedSpend.toFixed(2)} this period`;
   const displayedSubcategoryBreakdowns = hasBlockRounding
     ? subcategoryBreakdowns.map((entry) => ({ ...entry, totalSpend: entry.countedSpend }))
     : subcategoryBreakdowns;
@@ -119,51 +147,61 @@ export function CardSummaryCompactContent({
       <RefreshBadge isRefreshing={isRefreshing} />
       <div className="flex items-baseline justify-between gap-2">
         <span className="min-w-0 truncate text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-          {heroVariant === "cap-left" && (
+          {(heroVariant === "cap-left" || heroVariant === "cap-over") && (
             <>
-              Left of <CurrencyAmount value={maximumTarget} currency={currency} decimals={0} /> cap
-            </>
-          )}
-          {heroVariant === "cap-over" && (
-            <>
-              Over <CurrencyAmount value={maximumTarget} currency={currency} decimals={0} /> cap
+              <CurrencyAmount value={maximumTarget} currency={currency} decimals={0} /> cap
             </>
           )}
           {heroVariant === "min-left" && (
             <>
-              To <CurrencyAmount value={minimumTarget} currency={currency} decimals={0} /> min
+              <CurrencyAmount value={minimumTarget} currency={currency} decimals={0} /> min
             </>
           )}
-          {heroVariant === "spent" && "Spent"}
+          {heroVariant === "spent" && "This period"}
         </span>
         <span
-          className={cn(
-            "shrink-0 text-xl font-semibold leading-none tracking-tight",
-            heroVariant === "cap-over" && "text-red-600 dark:text-red-400",
-            heroVariant === "cap-left" && nearCap && "text-amber-600 dark:text-amber-400"
-          )}
-          title={
-            heroVariant === "cap-left"
-              ? `${remainingToMaximum.toFixed(2)} left before the cap`
-              : heroVariant === "cap-over"
-                ? `${exceededAmount.toFixed(2)} over the cap`
-                : heroVariant === "min-left"
-                  ? `${remainingToMinimum.toFixed(2)} more to meet the minimum`
-                  : `Spent ${displayedSpend.toFixed(2)} this period`
-          }
+          className={cn("flex shrink-0 items-baseline gap-1", heroTone)}
+          title={heroTitle}
+          aria-label={heroTitle}
         >
+          {heroVariant === "min-left" && (
+            <ArrowUpRight className="h-4 w-4 self-center" aria-hidden />
+          )}
           {heroVariant === "cap-left" && (
-            <CurrencyAmount value={remainingToMaximum} currency={currency} decimals={0} />
+            <Gauge className="h-4 w-4 self-center" aria-hidden />
           )}
           {heroVariant === "cap-over" && (
-            <CurrencyAmount value={exceededAmount} currency={currency} decimals={0} showPlus />
+            <OctagonAlert className="h-4 w-4 self-center" aria-hidden />
           )}
-          {heroVariant === "min-left" && (
-            <CurrencyAmount value={remainingToMinimum} currency={currency} decimals={0} />
-          )}
-          {heroVariant === "spent" && (
-            <CurrencyAmount value={displayedSpend} currency={currency} />
-          )}
+          <span
+            className={cn(
+              "text-xl leading-none tracking-tight tabular-nums",
+              heroVariant === "spent" || heroVariant === "cap-over"
+                ? "font-semibold"
+                : "font-medium"
+            )}
+          >
+            {heroVariant === "cap-left" && (
+              <CurrencyAmount value={remainingToMaximum} currency={currency} decimals={0} />
+            )}
+            {heroVariant === "cap-over" && (
+              <CurrencyAmount value={exceededAmount} currency={currency} decimals={0} showPlus />
+            )}
+            {heroVariant === "min-left" && (
+              <CurrencyAmount value={remainingToMinimum} currency={currency} decimals={0} />
+            )}
+            {heroVariant === "spent" && (
+              <CurrencyAmount value={displayedSpend} currency={currency} />
+            )}
+          </span>
+          <span
+            className={cn(
+              "text-[11px] font-medium",
+              heroVariant === "spent" ? "text-muted-foreground" : "opacity-70"
+            )}
+          >
+            {heroSuffix}
+          </span>
         </span>
       </div>
 

--- a/apps/web/components/SpendingProgressBar.tsx
+++ b/apps/web/components/SpendingProgressBar.tsx
@@ -188,10 +188,15 @@ export function SpendingProgressBar({
           />
         </div>
 
-        {/* Minimum spend marker */}
+        {/* Minimum spend marker — matches the amber "to go" hero while still pending */}
         {hasMinimum && minimumPosition !== null && (
           <div
-            className="absolute top-0 h-3 w-0.5 bg-foreground/40"
+            className={cn(
+              "absolute top-0 h-3 w-0.5",
+              spendingZone === 'pending'
+                ? "bg-amber-600 dark:bg-amber-400"
+                : "bg-foreground/40"
+            )}
             style={{
               left: `${minimumPosition}%`,
               transform: minimumPosition === 100 ? 'translateX(-100%)' : undefined
@@ -232,22 +237,22 @@ export function SpendingProgressBar({
             <div>
               {spendingZone === 'pending' && remainingToMinimum > 0 && (
                 <span className="text-amber-600 dark:text-amber-400">
-                  <CurrencyAmount value={remainingToMinimum} currency={currency} /> to minimum
+                  <CurrencyAmount value={remainingToMinimum} currency={currency} /> to go
                 </span>
               )}
               {spendingZone === 'earning' && hasMaximum && remainingToMaximum > 0 && (
                 <span className="text-emerald-600 dark:text-emerald-400">
-                  <CurrencyAmount value={remainingToMaximum} currency={currency} /> until cap
+                  <CurrencyAmount value={remainingToMaximum} currency={currency} /> left of cap
                 </span>
               )}
               {spendingZone === 'nearing' && remainingToMaximum > 0 && (
                 <span className="text-orange-600 dark:text-orange-400 font-medium">
-                  <CurrencyAmount value={remainingToMaximum} currency={currency} /> until cap
+                  <CurrencyAmount value={remainingToMaximum} currency={currency} /> left of cap
                 </span>
               )}
               {spendingZone === 'exceeded' && exceededAmount > 0 && (
                 <span className="text-red-600 dark:text-red-400 font-medium">
-                  <CurrencyAmount value={exceededAmount} currency={currency} /> over limit
+                  <CurrencyAmount value={exceededAmount} currency={currency} /> over cap
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Problem

Dashboard tiles showed three different quantities — shortfall to a minimum ("TO $1,600 MIN — $782"), headroom under a cap ("LEFT OF $1,000 CAP — $826"), and plain spend ("SPENT — $664.98") — in identical big-number styling. Meanings collided at a glance; only the tiny uppercase label distinguished a goal from a countdown from a status.

## Design

Explored with three parallel design passes (directional cues, systematic state colour, typographic framing) and synthesised the convergent recommendations:

- **Meaning travels with the number**: the qualifier now sits inline as a lockup — `$782 to go`, `$826 left`, `$664.98 spent`, `+$120 over` — resolvable in a single fixation instead of a saccade across the tile.
- **Shape before colour** (colourblind-safe): rising arrow for a minimum still being climbed, gauge for cap headroom being protected, stop octagon when over the cap, and deliberately *no* glyph for plain spend — absence signals "nothing to act on".
- **Valence-correct colour**: goal is steady amber ("keep going"); cap headroom stays neutral and only heats to amber near the cap, red over it — green was rejected as it instructs "keep spending", the wrong message for headroom to protect.
- **Real vs hypothetical money**: spent/over amounts render semibold (spent keeps cents — it's a receipt); goal/headroom amounts render a weight lighter and rounded (they're targets). `tabular-nums` keeps the anchor still across refreshes.
- The left label becomes a pure reference anchor: `$1,600 MIN`, `$1,000 CAP`, `THIS PERIOD`.
- The progress bar's minimum marker now matches the amber "to go" state, and its detail-view warning copy shares the hero vocabulary (`to go` / `left of cap` / `over cap`).

## Verification

- `pnpm --filter ./apps/web typecheck` clean; all 213 web tests pass.
- Rendered the live dashboard via dev server with seeded storage and mocked `/api/ynab/*` routes covering all six states (min pending, cap healthy, near cap, over cap, min met, no limits) in both light and dark themes — all lockups, glyphs, and tones render as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVSi2VcL8cFLhXjVMqbYnL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVSi2VcL8cFLhXjVMqbYnL)_