### PR TITLE
Quieten the minimum-goal hero to a neutral number

### DIFF
--- a/apps/web/components/CardSummaryCompact.tsx
+++ b/apps/web/components/CardSummaryCompact.tsx
@@ -96,15 +96,18 @@ export function CardSummaryCompactContent({
       : "spent";
 
   // The hero lockup pairs the amount with a directional glyph and a qualifier word so
-  // its meaning is legible without reading the label: a goal to spend into (amber,
-  // rising arrow), headroom to protect (gauge, heats up near the cap), or money
-  // already spent (no glyph — nothing to act on). Goal/headroom amounts are
-  // hypothetical, so they render rounded and a weight lighter than realised spend.
+  // its meaning is legible without reading the label: a goal to spend into (rising
+  // arrow), headroom to protect (gauge, heats up near the cap), or money already
+  // spent (no glyph — nothing to act on). Goal/headroom amounts are hypothetical,
+  // so they render rounded and a weight lighter than realised spend. Colour on the
+  // number is reserved for urgency (near/over cap) — the min goal keeps a neutral
+  // number since the amber progress bar and "% of min" fragment already carry
+  // that state, with only the arrow glyph keeping the goal accent.
   const capUrgent = heroVariant === "cap-left" && nearCap;
   const heroTone =
     heroVariant === "cap-over"
       ? "text-red-600 dark:text-red-400"
-      : heroVariant === "min-left" || capUrgent
+      : capUrgent
         ? "text-amber-600 dark:text-amber-400"
         : "text-foreground";
   const heroSuffix = {
@@ -165,7 +168,10 @@ export function CardSummaryCompactContent({
           aria-label={heroTitle}
         >
           {heroVariant === "min-left" && (
-            <ArrowUpRight className="h-4 w-4 self-center" aria-hidden />
+            <ArrowUpRight
+              className="h-4 w-4 self-center text-amber-600 dark:text-amber-400"
+              aria-hidden
+            />
           )}
           {heroVariant === "cap-left" && (
             <Gauge className="h-4 w-4 self-center" aria-hidden />

--- a/apps/web/components/SpendingProgressBar.tsx
+++ b/apps/web/components/SpendingProgressBar.tsx
@@ -188,15 +188,10 @@ export function SpendingProgressBar({
           />
         </div>
 
-        {/* Minimum spend marker — matches the amber "to go" hero while still pending */}
+        {/* Minimum spend marker */}
         {hasMinimum && minimumPosition !== null && (
           <div
-            className={cn(
-              "absolute top-0 h-3 w-0.5",
-              spendingZone === 'pending'
-                ? "bg-amber-600 dark:bg-amber-400"
-                : "bg-foreground/40"
-            )}
+            className="absolute top-0 h-3 w-0.5 bg-foreground/40"
             style={{
               left: `${minimumPosition}%`,
               transform: minimumPosition === 100 ? 'translateX(-100%)' : undefined


### PR DESCRIPTION
Follow-up to #91. The amber "$X to go" hero number tripled up on state the tile already signals through the amber progress fill and the "% of min" fragment — three orange elements for one non-urgent state.

- The minimum-goal number is now neutral (`text-foreground`); only the small rising-arrow glyph keeps the amber accent, so the goal semantics stay legible without the wall of orange.
- Hero-number colour is now reserved for genuine urgency: amber near the cap, red over it.
- Reverts the amber minimum marker on the progress bar, which sat invisibly against the amber pending fill anyway.

Verified with typecheck plus the same dev-server render across all six card states in light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVSi2VcL8cFLhXjVMqbYnL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVSi2VcL8cFLhXjVMqbYnL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spending progress indicators so urgency colors appear only when the spending limit is near its cap.
  * Updated the “minimum spend” marker to use consistent styling across spending states.
  * Preserved the amber indicator for the relevant minimum-spend status arrow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->