### PR TITLE
Tint hero numbers with near-black whispers of their zone colour

### DIFF
--- a/apps/web/components/CardSummaryCompact.tsx
+++ b/apps/web/components/CardSummaryCompact.tsx
@@ -97,19 +97,22 @@ export function CardSummaryCompactContent({
 
   // The hero lockup pairs the amount with a directional glyph and a qualifier word so
   // its meaning is legible without reading the label: a goal to spend into (rising
-  // arrow), headroom to protect (gauge, heats up near the cap), or money already
-  // spent (no glyph — nothing to act on). Goal/headroom amounts are hypothetical,
-  // so they render rounded and a weight lighter than realised spend. Colour on the
-  // number is reserved for urgency (near/over cap) — the min goal keeps a neutral
-  // number since the amber progress bar and "% of min" fragment already carry
-  // that state, with only the arrow glyph keeping the goal accent.
+  // arrow), headroom to protect (gauge), or money already spent (no glyph — nothing
+  // to act on). Goal/headroom amounts are hypothetical, so they render rounded and a
+  // weight lighter than realised spend. The number carries a whisper of its zone
+  // colour — near-black tints in light mode (-950), near-white in dark (-100) —
+  // echoing the progress bar underneath: orange while climbing to the min or nearing
+  // the cap, green while healthy, red when over. Loud alarm colour stays on the tile
+  // ring and bar; the number only hints.
   const capUrgent = heroVariant === "cap-left" && nearCap;
   const heroTone =
     heroVariant === "cap-over"
-      ? "text-red-600 dark:text-red-400"
-      : capUrgent
-        ? "text-amber-600 dark:text-amber-400"
-        : "text-foreground";
+      ? "text-red-950 dark:text-red-100"
+      : heroVariant === "min-left" || capUrgent
+        ? "text-orange-950 dark:text-orange-100"
+        : heroVariant === "cap-left" || (hasMinimum && minimumSpendMet)
+          ? "text-emerald-950 dark:text-emerald-100"
+          : "text-foreground";
   const heroSuffix = {
     "min-left": "to go",
     "cap-left": "left",
@@ -168,10 +171,7 @@ export function CardSummaryCompactContent({
           aria-label={heroTitle}
         >
           {heroVariant === "min-left" && (
-            <ArrowUpRight
-              className="h-4 w-4 self-center text-amber-600 dark:text-amber-400"
-              aria-hidden
-            />
+            <ArrowUpRight className="h-4 w-4 self-center" aria-hidden />
           )}
           {heroVariant === "cap-left" && (
             <Gauge className="h-4 w-4 self-center" aria-hidden />


### PR DESCRIPTION
Follow-up to #91/#92. Each hero amount now carries a barely-there tint echoing the progress bar's zone beneath it — orange while climbing to the minimum or nearing the cap, green while healthy (headroom or minimum met), red when over — instead of neutral numbers with loud colour reserved for urgency.

- Light mode uses the near-black `-950` shades (orange/emerald/red), dark mode the near-white `-100` shades, so the hue registers subliminally without adding loudness.
- Alarm-level colour remains where it was: the tile ring and the progress bar.
- The rising-arrow glyph inherits the same subtle tone rather than its previous amber accent.

Verified by pixel-sampling rendered screenshots across all six card states in both themes — each number resolves to exactly the intended `-950`/`-100` shade; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVSi2VcL8cFLhXjVMqbYnL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVSi2VcL8cFLhXjVMqbYnL)_