### PR TITLE
feat: simplify and refocus the iOS rewards experience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,10 @@ pnpm --filter ./apps/mobile android    # Launch Android emulator via Expo
 
 ### Mobile App
 - Use the scripts in `apps/mobile/package.json` for local Expo builds. Inspect the current Expo/EAS configuration before changing release workflows.
+- Keep iOS information hierarchy quiet and native: navigation titles should name the current object or destination, and screen content must not repeat them.
+- Do not decorate routine facts with dots, pills, badges, colours, uppercase eyebrows, or success labels. Normal states such as connected, active, linked, tracking, earning, and up to date should usually be silent; reserve emphasis for actions, decisions, warnings, errors, and exceptional states.
+- Prefer deleting redundant copy or controls over restyling them. Pull-to-refresh owns routine refresh, native navigation owns dismissal, and one clear content action should own a form commit.
+- Preserve meaningful data encodings such as YNAB flag colours and threshold/cap progress. Review optical alignment on a simulator rather than assuming a technically centred custom navigation view will look native.
 
 ## Contributing Guidelines
 - TypeScript-first development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ pnpm --filter ./apps/mobile android    # Launch Android emulator via Expo
 - Keep iOS information hierarchy quiet and native: navigation titles should name the current object or destination, and screen content must not repeat them.
 - Do not decorate routine facts with dots, pills, badges, colours, uppercase eyebrows, or success labels. Normal states such as connected, active, linked, tracking, earning, and up to date should usually be silent; reserve emphasis for actions, decisions, warnings, errors, and exceptional states.
 - Prefer deleting redundant copy or controls over restyling them. Pull-to-refresh owns routine refresh, native navigation owns dismissal, and one clear content action should own a form commit.
+- Make the mobile Overview forward-looking: prioritise which cards can still earn and their strongest factual use over prominent earned-value totals. Omit cards whose current-cycle cap is already reached; Cards and card detail remain the complete portfolio record.
 - Preserve meaningful data encodings such as YNAB flag colours and threshold/cap progress. Review optical alignment on a simulator rather than assuming a technically centred custom navigation view will look native.
 
 ## Contributing Guidelines

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -6,49 +6,52 @@ import { featureFlags } from '@ynab-counter/app-core/config/featureFlags';
 
 export default function TabsLayout() {
   const supportsTabMinimisation = Platform.OS === 'ios' && Number(Platform.Version) >= 26;
+  const triggers = [
+    <NativeTabs.Trigger key="overview" name="overview">
+      <Icon
+        sf={{ default: 'rectangle.grid.1x2', selected: 'rectangle.grid.1x2.fill' }}
+        androidSrc={require('../../assets/tabs/overview.png')}
+      />
+      <Label>Overview</Label>
+    </NativeTabs.Trigger>,
+    <NativeTabs.Trigger key="cards" name="cards">
+      <Icon
+        sf={{ default: 'creditcard', selected: 'creditcard.fill' }}
+        androidSrc={require('../../assets/tabs/cards.png')}
+      />
+      <Label>Cards</Label>
+    </NativeTabs.Trigger>,
+    <NativeTabs.Trigger key="activity" name="activity">
+      <Icon
+        sf={{ default: 'list.bullet.rectangle', selected: 'list.bullet.rectangle.fill' }}
+        androidSrc={require('../../assets/tabs/activity.png')}
+      />
+      <Label>Activity</Label>
+    </NativeTabs.Trigger>,
+    ...(featureFlags.recommendations ? [
+      <NativeTabs.Trigger key="recommendations" name="recommendations">
+        <Icon
+          sf={{ default: 'lightbulb', selected: 'lightbulb.fill' }}
+          androidSrc={require('../../assets/tabs/tips.png')}
+        />
+        <Label>Tips</Label>
+      </NativeTabs.Trigger>,
+    ] : []),
+    <NativeTabs.Trigger key="preferences" name="preferences">
+      <Icon
+        sf={{ default: 'gearshape', selected: 'gearshape.fill' }}
+        androidSrc={require('../../assets/tabs/settings.png')}
+      />
+      <Label>Settings</Label>
+    </NativeTabs.Trigger>,
+  ];
 
   return (
     <NativeTabs
       tintColor={semanticColors.action}
       minimizeBehavior={supportsTabMinimisation ? 'onScrollDown' : undefined}
     >
-      <NativeTabs.Trigger name="overview">
-        <Icon
-          sf={{ default: 'rectangle.grid.1x2', selected: 'rectangle.grid.1x2.fill' }}
-          androidSrc={require('../../assets/tabs/overview.png')}
-        />
-        <Label>Overview</Label>
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="cards">
-        <Icon
-          sf={{ default: 'creditcard', selected: 'creditcard.fill' }}
-          androidSrc={require('../../assets/tabs/cards.png')}
-        />
-        <Label>Cards</Label>
-      </NativeTabs.Trigger>
-      <NativeTabs.Trigger name="activity">
-        <Icon
-          sf={{ default: 'list.bullet.rectangle', selected: 'list.bullet.rectangle.fill' }}
-          androidSrc={require('../../assets/tabs/activity.png')}
-        />
-        <Label>Activity</Label>
-      </NativeTabs.Trigger>
-      {featureFlags.recommendations ? (
-        <NativeTabs.Trigger name="recommendations">
-          <Icon
-            sf={{ default: 'lightbulb', selected: 'lightbulb.fill' }}
-            androidSrc={require('../../assets/tabs/tips.png')}
-          />
-          <Label>Tips</Label>
-        </NativeTabs.Trigger>
-      ) : null}
-      <NativeTabs.Trigger name="preferences">
-        <Icon
-          sf={{ default: 'gearshape', selected: 'gearshape.fill' }}
-          androidSrc={require('../../assets/tabs/settings.png')}
-        />
-        <Label>Settings</Label>
-      </NativeTabs.Trigger>
+      {triggers}
     </NativeTabs>
   );
 }

--- a/apps/mobile/app/(tabs)/activity/[id].tsx
+++ b/apps/mobile/app/(tabs)/activity/[id].tsx
@@ -351,7 +351,7 @@ export default function TransactionDetailScreen() {
         automaticallyAdjustsScrollIndicatorInsets
       >
         <View style={styles.hero}>
-          <Caption1 color="secondary" style={styles.eyebrow}>TRANSACTION</Caption1>
+          <Caption1 color="secondary">Transaction</Caption1>
           <Title1 accessibilityRole="header">{payee}</Title1>
           <LargeTitle
             style={projection.status === 'incoming' ? styles.incoming : undefined}
@@ -462,10 +462,6 @@ const styles = StyleSheet.create({
   },
   hero: {
     gap: spacing.sm,
-  },
-  eyebrow: {
-    fontWeight: '700',
-    letterSpacing: 0.7,
   },
   incoming: {
     color: semanticColors.positive,

--- a/apps/mobile/app/(tabs)/cards/index.tsx
+++ b/apps/mobile/app/(tabs)/cards/index.tsx
@@ -291,6 +291,7 @@ const styles = StyleSheet.create({
   },
   manageButton: {
     minHeight: nativeMetrics.minimumTouchTarget,
+    marginLeft: 'auto',
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -1,84 +1,246 @@
 import React, { useMemo } from 'react';
 import {
+  Pressable,
   RefreshControl,
   ScrollView,
   StyleSheet,
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import { SymbolView } from 'expo-symbols';
 
 import { useStorage } from '@/contexts/StorageContext';
 import {
-  CardStatusRow,
   EmptyState,
   LargeNavigationTitle,
-  MetricValue,
   SectionTitle,
   SyncBadge,
 } from '@/components/native';
 import {
   Body,
+  Footnote,
+  Headline,
   LargeTitle,
 } from '@/components/ios';
 import {
-  createCardFormatting,
-  formatDaysRemaining,
-  formatPeriod,
-  formatReward,
-  primaryProgress,
-  statusPresentation,
   attentionCopy,
+  createCardFormatting,
+  flagColor,
+  formatResetDate,
+  type CardFormatting,
 } from '@/features/cards/presentation';
 import { useRewardsDashboard } from '@/features/cards/dashboard';
-import { RewardCategorySummary } from '@/features/cards/RewardCategoryBreakdown';
+import { RewardCategoryRow } from '@/features/cards/RewardCategoryBreakdown';
 import {
   collectRewardCategories,
+  rankRewardCategoryEarnings,
   rankRewardCategoryPreview,
+  type PortfolioRewardCategory,
 } from '@/features/cards/reward-categories';
 import { semanticColors } from '@/theme';
-import { nativeMetrics, spacing } from '@/theme/tokens';
+import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
 import type { CardDashboardProjection } from '@ynab-counter/app-core/rewards-engine';
 
-function CardProjectionRow({
+function compactCardName(name: string): string {
+  const segments = name
+    .split(/\s+·\s+/u)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  return segments.at(-1) ?? name;
+}
+
+function attentionDetail({
   projection,
-  formatCurrency,
-  rewardValue,
-  context,
+  formatting,
+}: {
+  projection: CardDashboardProjection;
+  formatting: CardFormatting;
+}): string | undefined {
+  switch (projection.status) {
+    case 'building':
+      return projection.minimum.target === null
+        ? undefined
+        : `${formatting.currencyCompact(projection.spend.total)} of ${formatting.currencyCompact(projection.minimum.target)} · ${projection.daysRemaining} ${projection.daysRemaining === 1 ? 'day' : 'days'} left`;
+    case 'near_cap':
+    case 'capped':
+      return projection.maximum.target === null
+        ? undefined
+        : `${formatting.currencyCompact(projection.progress.maximumProgressSpend)} of ${formatting.currencyCompact(projection.maximum.target)} · resets ${formatResetDate(projection.resetsOn)}`;
+    case 'unconfigured':
+      return projection.card.issuer === 'Unknown' ? undefined : projection.card.issuer;
+    case 'earning':
+    case 'open':
+      return undefined;
+  }
+}
+
+function AttentionCardRow({
+  projection,
+  formatting,
   onPress,
   showDivider,
 }: {
   projection: CardDashboardProjection;
-  formatCurrency: (value: number) => string;
-  rewardValue: string;
-  context: string;
+  formatting: CardFormatting;
   onPress: () => void;
   showDivider: boolean;
 }) {
-  const blockDetail = projection.blockInfo
-    ? projection.blockInfo.uncountedEligibleSpend > 0
-      ? `${projection.blockInfo.sizes.map((size) => formatCurrency(size)).join('/')} blocks · ${formatCurrency(projection.blockInfo.uncountedEligibleSpend)} not counted`
-      : `${projection.blockInfo.sizes.map((size) => formatCurrency(size)).join('/')} blocks`
-    : undefined;
-  const periodLabel = [context, blockDetail].filter(Boolean).join(' · ');
-  const progress = primaryProgress(projection);
+  const action = projection.status === 'capped'
+    ? 'Cap reached · use another card'
+    : attentionCopy(projection, formatting);
+  const detail = attentionDetail({ projection, formatting });
+  const actionColor = projection.status === 'capped' ? 'destructive' : 'attention';
 
   return (
-    <CardStatusRow
-      name={projection.card.name}
-      issuer={projection.card.issuer === 'Unknown' ? undefined : projection.card.issuer}
-      periodLabel={periodLabel}
-      rewardValue={rewardValue}
-      rewardLabel={projection.card.type === 'miles' ? 'Miles earned' : 'Cashback earned'}
-      spend={progress.spend}
-      formatValue={formatCurrency}
-      minimumSpend={progress.minimum}
-      maximumSpend={progress.maximum}
-      status={statusPresentation(projection.status)}
+    <Pressable
       onPress={onPress}
-      showDivider={showDivider}
-    />
+      accessibilityRole="button"
+      accessibilityLabel={[projection.card.name, action, detail].filter(Boolean).join(', ')}
+      accessibilityHint="Opens card details"
+      style={({ pressed }) => [
+        styles.attentionRow,
+        showDivider && styles.rowDivider,
+        pressed && styles.pressed,
+      ]}
+    >
+      <View style={styles.rowHeading} accessibilityElementsHidden>
+        <Headline style={styles.rowTitle}>{projection.card.name}</Headline>
+        <SymbolView
+          name="chevron.right"
+          size={11}
+          tintColor={semanticColors.tertiaryLabel}
+        />
+      </View>
+      <Headline color={actionColor} accessibilityElementsHidden>{action}</Headline>
+      {detail ? <Footnote color="secondary" accessibilityElementsHidden>{detail}</Footnote> : null}
+    </Pressable>
   );
 }
+
+function CardEarningsRow({
+  projection,
+  formatting,
+  onPress,
+  showDivider,
+}: {
+  projection: CardDashboardProjection;
+  formatting: CardFormatting;
+  onPress: () => void;
+  showDivider: boolean;
+}) {
+  const isUnconfigured = projection.status === 'unconfigured';
+  const rewardValue = isUnconfigured
+    ? 'Not calculated'
+    : projection.reward.type === 'cashback'
+      ? formatting.currencyExact(projection.reward.amount)
+      : `${formatting.number(projection.reward.amount)} miles`;
+  const rewardDetail = isUnconfigured
+    ? undefined
+    : projection.reward.type === 'cashback'
+      ? 'cashback'
+      : `≈ ${formatting.currencyExact(projection.reward.dollars)}`;
+  const cardContext = [
+    projection.card.issuer === 'Unknown' ? undefined : projection.card.issuer,
+    `${formatting.currencyCompact(projection.spend.total)} spent`,
+    `resets ${formatResetDate(projection.resetsOn)}`,
+  ].filter(Boolean).join(' · ');
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${projection.card.name}, ${rewardValue}${rewardDetail ? ` ${rewardDetail}` : ''}, ${cardContext}`}
+      accessibilityHint="Opens card details"
+      style={({ pressed }) => [
+        styles.earningsRow,
+        showDivider && styles.rowDivider,
+        pressed && styles.pressed,
+      ]}
+    >
+      <View style={styles.earningsCopy} accessibilityElementsHidden>
+        <Headline numberOfLines={2}>{projection.card.name}</Headline>
+        <Footnote color="secondary">{cardContext}</Footnote>
+      </View>
+      <View style={styles.earningsValue} accessibilityElementsHidden>
+        <Headline color={isUnconfigured ? 'secondary' : 'primary'} style={styles.tabular}>
+          {rewardValue}
+        </Headline>
+        {rewardDetail ? <Footnote color="secondary">{rewardDetail}</Footnote> : null}
+      </View>
+      <SymbolView
+        name="chevron.right"
+        size={11}
+        tintColor={semanticColors.tertiaryLabel}
+        accessibilityElementsHidden
+      />
+    </Pressable>
+  );
+}
+
+function CategoryEarningsRow({
+  item,
+  formatting,
+  onPress,
+  showDivider,
+}: {
+  item: PortfolioRewardCategory;
+  formatting: CardFormatting;
+  onPress: () => void;
+  showDivider: boolean;
+}) {
+  const rewardValue = item.category.reward.type === 'cashback'
+    ? formatting.currencyExact(item.category.reward.amount)
+    : `${formatting.number(item.category.reward.amount)} miles`;
+  const rewardDetail = item.category.reward.type === 'cashback'
+    ? 'cashback'
+    : `≈ ${formatting.currencyExact(item.category.reward.dollars)}`;
+  const context = `${compactCardName(item.card.card.name)} · ${formatting.currencyCompact(item.category.spend.total)} spent`;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.category.name}, ${item.card.card.name}, ${rewardValue} ${rewardDetail}, ${formatting.currencyCompact(item.category.spend.total)} spent`}
+      accessibilityHint={`Opens the ${item.category.name} reward tier on ${item.card.card.name}`}
+      style={({ pressed }) => [
+        styles.earningsRow,
+        showDivider && styles.rowDivider,
+        pressed && styles.pressed,
+      ]}
+    >
+      <SymbolView
+        name="flag.fill"
+        size={15}
+        tintColor={flagColor(item.category.flagColor)}
+        style={styles.flagIcon}
+        accessibilityElementsHidden
+      />
+      <View style={styles.earningsCopy} accessibilityElementsHidden>
+        <Headline numberOfLines={2}>{item.category.name}</Headline>
+        <Footnote color="secondary">{context}</Footnote>
+      </View>
+      <View style={styles.earningsValue} accessibilityElementsHidden>
+        <Headline style={styles.tabular}>{rewardValue}</Headline>
+        <Footnote color="secondary">{rewardDetail}</Footnote>
+      </View>
+      <SymbolView
+        name="chevron.right"
+        size={11}
+        tintColor={semanticColors.tertiaryLabel}
+        accessibilityElementsHidden
+      />
+    </Pressable>
+  );
+}
+
+const attentionPriority: Record<CardDashboardProjection['status'], number> = {
+  capped: 0,
+  near_cap: 1,
+  building: 2,
+  unconfigured: 3,
+  earning: 4,
+  open: 5,
+};
 
 export default function OverviewScreen() {
   const router = useRouter();
@@ -93,8 +255,6 @@ export default function OverviewScreen() {
         totals.cashback += projection.reward.type === 'cashback' ? projection.reward.amount : 0;
         totals.miles += projection.reward.type === 'miles' ? projection.reward.amount : 0;
         totals.milesValue += projection.reward.type === 'miles' ? projection.reward.dollars : 0;
-        totals.spend += projection.spend.total;
-        totals.counts[projection.status] += 1;
         return totals;
       },
       {
@@ -102,15 +262,6 @@ export default function OverviewScreen() {
         cashback: 0,
         miles: 0,
         milesValue: 0,
-        spend: 0,
-        counts: {
-          unconfigured: 0,
-          building: 0,
-          earning: 0,
-          near_cap: 0,
-          capped: 0,
-          open: 0,
-        } satisfies Record<CardDashboardProjection['status'], number>,
       },
     ),
     [model.visibleCards],
@@ -124,6 +275,39 @@ export default function OverviewScreen() {
     () => rankRewardCategoryPreview(rewardCategories),
     [rewardCategories],
   );
+  const tierAttentionPreview = useMemo(
+    () => rankRewardCategoryPreview(rewardCategories, rewardCategories.length)
+      .filter(({ category }) => (
+        !category.excluded &&
+        !category.blockedByCardMinimum &&
+        (
+          category.maximum.reached ||
+          (category.maximum.progress ?? 0) >= 0.8 ||
+          (category.minimum.target !== null && category.minimum.met === false)
+        )
+      ))
+      .slice(0, 3),
+    [rewardCategories],
+  );
+  const earnedCategoryPreview = useMemo(
+    () => rankRewardCategoryEarnings(rewardCategories),
+    [rewardCategories],
+  );
+  const attentionCards = useMemo(
+    () => [...model.attentionCards].sort(
+      (left, right) => attentionPriority[left.status] - attentionPriority[right.status],
+    ),
+    [model.attentionCards],
+  );
+  const nativeRewardSummary = [
+    visibleTotals.cashback > 0
+      ? `${formatting.currencyExact(visibleTotals.cashback)} cashback`
+      : undefined,
+    visibleTotals.miles > 0
+      ? `${formatting.number(visibleTotals.miles)} miles ≈ ${formatting.currencyExact(visibleTotals.milesValue)}`
+      : undefined,
+  ].filter(Boolean).join(' · ');
+  const attentionCount = attentionCards.length + tierAttentionPreview.length;
 
   const openCard = (id: string) => {
     router.push({ pathname: '/card/[id]', params: { id } });
@@ -187,107 +371,104 @@ export default function OverviewScreen() {
       ) : (
         <>
           <View style={styles.hero}>
+            <View
+              accessible
+              accessibilityRole="summary"
+              accessibilityLabel={`Estimated reward value ${formatting.currencyExact(visibleTotals.value)} across current card cycles${nativeRewardSummary ? `, ${nativeRewardSummary}` : ''}`}
+            >
+              <LargeTitle style={styles.heroValue} accessible={false}>
+                {formatting.currencyExact(visibleTotals.value)}
+              </LargeTitle>
+              <Body color="secondary" accessible={false}>
+                Estimated value · current card cycles
+              </Body>
+              {nativeRewardSummary ? (
+                <Footnote color="secondary" style={styles.rewardBreakdown} accessible={false}>
+                  {nativeRewardSummary}
+                </Footnote>
+              ) : null}
+            </View>
             <SyncBadge
               state={model.syncState}
               label={model.syncLabel}
               onPress={model.canSync ? model.refresh : () => router.push('/settings')}
               accessibilityHint={model.canSync ? 'Refreshes rewards from YNAB' : 'Opens YNAB settings'}
             />
-
-            <View accessible accessibilityRole="summary" accessibilityLabel={`Estimated reward value ${formatting.currencyExact(visibleTotals.value)}`}>
-              <LargeTitle style={styles.heroValue} accessible={false}>
-                {formatting.currencyExact(visibleTotals.value)}
-              </LargeTitle>
-              <Body color="secondary" accessible={false}>
-                Estimated reward value
-              </Body>
-            </View>
-
-            <View style={styles.nativeTotals}>
-              <MetricValue
-                label="Cashback"
-                value={formatting.currencyExact(visibleTotals.cashback)}
-                size="compact"
-              />
-              <View style={styles.metricDivider} />
-              <MetricValue
-                label="Miles"
-                value={formatting.number(visibleTotals.miles)}
-                detail={`≈ ${formatting.currencyExact(visibleTotals.milesValue)}`}
-                size="compact"
-              />
-              <View style={styles.metricDivider} />
-              <MetricValue
-                label="Spend tracked"
-                value={formatting.currencyCompact(visibleTotals.spend)}
-                size="compact"
-              />
-            </View>
-
-            <RewardCategorySummary
-              categories={rewardCategories}
-              preview={categoryPreview}
-              formatting={formatting}
-              setupCount={visibleTotals.counts.unconfigured}
-              onSeeAll={openRewardCategories}
-              onOpenCard={openRewardCategory}
-              onReviewCards={() => router.push('/(tabs)/cards')}
-            />
           </View>
 
-          {model.attentionCards.length > 0 ? (
+          {attentionCount > 0 ? (
             <View style={styles.section}>
-              <SectionTitle
-                title="Needs attention"
-              />
+              <SectionTitle title="Needs attention" />
               <View style={styles.rows}>
-                {model.attentionCards.map((projection, index) => (
-                  <CardProjectionRow
+                {attentionCards.map((projection, index) => (
+                  <AttentionCardRow
                     key={projection.card.id}
                     projection={projection}
-                    rewardValue={formatReward(projection, formatting)}
-                    formatCurrency={formatting.currencyCompact}
-                    context={attentionCopy(projection, formatting)}
+                    formatting={formatting}
                     onPress={() => openCard(projection.card.id)}
-                    showDivider={index < model.attentionCards.length - 1}
+                    showDivider={index < attentionCards.length - 1 || tierAttentionPreview.length > 0}
+                  />
+                ))}
+                {tierAttentionPreview.map((item, index) => (
+                  <RewardCategoryRow
+                    key={item.key}
+                    item={item}
+                    formatting={formatting}
+                    onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
+                    showDivider={index < tierAttentionPreview.length - 1}
                   />
                 ))}
               </View>
             </View>
           ) : null}
 
-          {model.trackingCards.length > 0 ? (
+          <View style={styles.section}>
+            <SectionTitle title="Earned by card" />
+            <View style={styles.rows}>
+              {model.visibleCards.map((projection, index) => (
+                <CardEarningsRow
+                  key={projection.card.id}
+                  projection={projection}
+                  formatting={formatting}
+                  onPress={() => openCard(projection.card.id)}
+                  showDivider={index < model.visibleCards.length - 1}
+                />
+              ))}
+            </View>
+          </View>
+
+          {categoryPreview.length > 0 ? (
             <View style={styles.section}>
               <SectionTitle
-                title={model.attentionCards.length > 0 ? 'On track' : 'Your cards'}
-                subtitle={`${model.trackingCards.length} ${model.trackingCards.length === 1 ? 'card' : 'cards'} on Overview`}
+                title={earnedCategoryPreview.length > 0 ? 'Earned by category' : 'Reward categories'}
                 action={{
-                  label: 'All cards',
-                  onPress: () => router.push('/(tabs)/cards'),
-                  accessibilityHint: 'Opens card management',
+                  label: 'See all',
+                  onPress: openRewardCategories,
+                  accessibilityHint: 'Opens every reward category on Overview, grouped by card',
                 }}
               />
               <View style={styles.rows}>
-                {model.trackingCards.map((projection, index) => (
-                  <CardProjectionRow
-                    key={projection.card.id}
-                    projection={projection}
-                    rewardValue={formatReward(projection, formatting)}
-                    formatCurrency={formatting.currencyCompact}
-                    context={`${formatPeriod(projection.period)} · ${formatDaysRemaining(projection.daysRemaining, projection.resetsOn)}`}
-                    onPress={() => openCard(projection.card.id)}
-                    showDivider={index < model.trackingCards.length - 1}
-                  />
-                ))}
+                {earnedCategoryPreview.length > 0
+                  ? earnedCategoryPreview.map((item, index) => (
+                      <CategoryEarningsRow
+                        key={item.key}
+                        item={item}
+                        formatting={formatting}
+                        onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
+                        showDivider={index < earnedCategoryPreview.length - 1}
+                      />
+                    ))
+                  : categoryPreview.map((item, index) => (
+                      <RewardCategoryRow
+                        key={item.key}
+                        item={item}
+                        formatting={formatting}
+                        onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
+                        showDivider={index < categoryPreview.length - 1}
+                      />
+                    ))}
               </View>
             </View>
-          ) : null}
-
-          {model.trackingCards.length === 0 ? (
-            <SectionTitle
-              title="Card management"
-              action={{ label: 'All cards', onPress: () => router.push('/(tabs)/cards') }}
-            />
           ) : null}
         </>
       )}
@@ -311,7 +492,7 @@ const styles = StyleSheet.create({
   },
   hero: {
     paddingTop: spacing.sm,
-    gap: spacing.xl,
+    gap: spacing.md,
   },
   heroValue: {
     fontSize: 44,
@@ -319,25 +500,64 @@ const styles = StyleSheet.create({
     fontVariant: ['tabular-nums'],
     letterSpacing: -1.2,
   },
-  nativeTotals: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'stretch',
-    columnGap: spacing.lg,
-    rowGap: spacing.lg,
-  },
-  metricDivider: {
-    width: StyleSheet.hairlineWidth,
-    minHeight: 42,
-    backgroundColor: semanticColors.separator,
+  rewardBreakdown: {
+    marginTop: spacing.sm,
+    fontVariant: ['tabular-nums'],
   },
   section: {
     gap: spacing.md,
   },
   rows: {
     marginHorizontal: -spacing.md,
-    borderRadius: 16,
+    borderRadius: radii.large,
     backgroundColor: semanticColors.secondarySystemGroupedBackground,
     overflow: 'hidden',
+  },
+  attentionRow: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    gap: spacing.sm,
+  },
+  rowHeading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  rowTitle: {
+    flex: 1,
+  },
+  earningsRow: {
+    minHeight: 72,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  earningsCopy: {
+    flex: 1,
+    minWidth: 0,
+    gap: spacing.xs,
+  },
+  earningsValue: {
+    flexShrink: 0,
+    maxWidth: 120,
+    alignItems: 'flex-end',
+    gap: spacing.xs,
+  },
+  flagIcon: {
+    flexShrink: 0,
+  },
+  tabular: {
+    fontVariant: ['tabular-nums'],
+    textAlign: 'right',
+  },
+  rowDivider: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: semanticColors.separator,
+  },
+  pressed: {
+    opacity: interaction.subtlePressedOpacity,
   },
 });

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -14,28 +14,21 @@ import {
   EmptyState,
   LargeNavigationTitle,
   SectionTitle,
-  SyncBadge,
 } from '@/components/native';
+import { Body, Footnote, Headline } from '@/components/ios';
 import {
-  Body,
-  Footnote,
-  Headline,
-  LargeTitle,
-} from '@/components/ios';
-import {
-  attentionCopy,
   createCardFormatting,
   flagColor,
   formatResetDate,
   type CardFormatting,
 } from '@/features/cards/presentation';
 import { useRewardsDashboard } from '@/features/cards/dashboard';
-import { RewardCategoryRow } from '@/features/cards/RewardCategoryBreakdown';
 import {
   collectRewardCategories,
-  rankRewardCategoryEarnings,
+  rankCardUses,
   rankRewardCategoryPreview,
   type PortfolioRewardCategory,
+  type RankedCardUse,
 } from '@/features/cards/reward-categories';
 import { semanticColors } from '@/theme';
 import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
@@ -49,135 +42,186 @@ function compactCardName(name: string): string {
   return segments.at(-1) ?? name;
 }
 
-function attentionDetail({
-  projection,
-  formatting,
-}: {
-  projection: CardDashboardProjection;
-  formatting: CardFormatting;
-}): string | undefined {
-  switch (projection.status) {
-    case 'building':
-      return projection.minimum.target === null
-        ? undefined
-        : `${formatting.currencyCompact(projection.spend.total)} of ${formatting.currencyCompact(projection.minimum.target)} · ${projection.daysRemaining} ${projection.daysRemaining === 1 ? 'day' : 'days'} left`;
-    case 'near_cap':
-    case 'capped':
-      return projection.maximum.target === null
-        ? undefined
-        : `${formatting.currencyCompact(projection.progress.maximumProgressSpend)} of ${formatting.currencyCompact(projection.maximum.target)} · resets ${formatResetDate(projection.resetsOn)}`;
-    case 'unconfigured':
-      return projection.card.issuer === 'Unknown' ? undefined : projection.card.issuer;
-    case 'earning':
-    case 'open':
-      return undefined;
+function decisionCurrency(value: number, formatting: CardFormatting): string {
+  if (value !== 0 && Math.abs(value) < 1) {
+    return formatting.currencyExact(value);
   }
+  return `${formatting.currency} ${new Intl.NumberFormat('en-GB', {
+    maximumFractionDigits: 0,
+  }).format(value)}`;
 }
 
-function AttentionCardRow({
-  projection,
+function thresholdCurrency(value: number, formatting: CardFormatting): string {
+  return Number.isInteger(value)
+    ? decisionCurrency(value, formatting)
+    : formatting.currencyExact(value);
+}
+
+function categoryRateLabel(
+  item: PortfolioRewardCategory,
+  formatting: CardFormatting,
+): string {
+  const rate = formatting.number(item.category.rate);
+  const label = item.card.card.type === 'cashback'
+    ? `${rate}% cashback`
+    : `${rate} ${item.category.rate === 1 ? 'mile' : 'miles'}/${formatting.currency} 1`;
+  return item.category.blockInfo
+    ? `${label} · ${thresholdCurrency(item.category.blockInfo.size, formatting)} blocks`
+    : label;
+}
+
+function cardUseRateLabel(
+  item: RankedCardUse,
+  formatting: CardFormatting,
+): string {
+  const rate = formatting.number(item.rate.value);
+  const nativeRate = item.rate.type === 'cashback'
+    ? `${rate}% cashback`
+    : `${rate} ${item.rate.value === 1 ? 'mile' : 'miles'}/${formatting.currency} 1`;
+  const blockAwareRate = item.rate.blockSize === null
+    ? nativeRate
+    : `${nativeRate} · ${thresholdCurrency(item.rate.blockSize, formatting)} blocks`;
+  return item.rate.prospective ? `${blockAwareRate} after unlock` : blockAwareRate;
+}
+
+function cardUseOperationalLabel(
+  item: RankedCardUse,
+  formatting: CardFormatting,
+): string | undefined {
+  if (item.operational?.kind === 'minimum') {
+    return `${thresholdCurrency(item.operational.remaining, formatting)} more by ${formatResetDate(item.operational.resetsOn)} to unlock`;
+  }
+  if (item.operational?.kind === 'cap') {
+    return `${thresholdCurrency(item.operational.remaining, formatting)} cap room`;
+  }
+  return undefined;
+}
+
+function CardUseRow({
+  item,
   formatting,
   onPress,
   showDivider,
 }: {
-  projection: CardDashboardProjection;
+  item: RankedCardUse;
   formatting: CardFormatting;
   onPress: () => void;
   showDivider: boolean;
 }) {
-  const action = projection.status === 'capped'
-    ? 'Cap reached · use another card'
-    : attentionCopy(projection, formatting);
-  const detail = attentionDetail({ projection, formatting });
-  const actionColor = projection.status === 'capped' ? 'destructive' : 'attention';
+  const rateLabel = cardUseRateLabel(item, formatting);
+  const operationalLabel = cardUseOperationalLabel(item, formatting);
 
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={[projection.card.name, action, detail].filter(Boolean).join(', ')}
-      accessibilityHint="Opens card details"
+      accessibilityLabel={[
+        item.card.card.name,
+        item.use.label,
+        rateLabel,
+        operationalLabel,
+      ].filter(Boolean).join(', ')}
+      accessibilityHint={item.use.categoryId
+        ? `Opens the ${item.use.label} earning tier on ${item.card.card.name}`
+        : `Opens details for ${item.card.card.name}`}
       style={({ pressed }) => [
-        styles.attentionRow,
+        styles.cardUseRow,
         showDivider && styles.rowDivider,
         pressed && styles.pressed,
       ]}
     >
-      <View style={styles.rowHeading} accessibilityElementsHidden>
-        <Headline style={styles.rowTitle}>{projection.card.name}</Headline>
-        <SymbolView
-          name="chevron.right"
-          size={11}
-          tintColor={semanticColors.tertiaryLabel}
-        />
+      <View style={styles.rowCopy} accessibilityElementsHidden>
+        <Headline>{compactCardName(item.card.card.name)}</Headline>
+        <View style={styles.useLabelRow}>
+          {item.use.flagColor ? (
+            <SymbolView
+              name="flag.fill"
+              size={14}
+              tintColor={flagColor(item.use.flagColor)}
+              style={styles.flagIcon}
+            />
+          ) : null}
+          <Body style={styles.flexibleText}>{item.use.label} · {rateLabel}</Body>
+        </View>
+        {operationalLabel ? (
+          <Footnote color="secondary" style={styles.tabular}>
+            {operationalLabel}
+          </Footnote>
+        ) : null}
       </View>
-      <Headline color={actionColor} accessibilityElementsHidden>{action}</Headline>
-      {detail ? <Footnote color="secondary" accessibilityElementsHidden>{detail}</Footnote> : null}
     </Pressable>
   );
 }
 
-function CardEarningsRow({
+function SetupCardRow({
   projection,
-  formatting,
   onPress,
   showDivider,
 }: {
   projection: CardDashboardProjection;
-  formatting: CardFormatting;
   onPress: () => void;
   showDivider: boolean;
 }) {
-  const isUnconfigured = projection.status === 'unconfigured';
-  const rewardValue = isUnconfigured
-    ? 'Not calculated'
-    : projection.reward.type === 'cashback'
-      ? formatting.currencyExact(projection.reward.amount)
-      : `${formatting.number(projection.reward.amount)} miles`;
-  const rewardDetail = isUnconfigured
-    ? undefined
-    : projection.reward.type === 'cashback'
-      ? 'cashback'
-      : `≈ ${formatting.currencyExact(projection.reward.dollars)}`;
-  const cardContext = [
-    projection.card.issuer === 'Unknown' ? undefined : projection.card.issuer,
-    `${formatting.currencyCompact(projection.spend.total)} spent`,
-    `resets ${formatResetDate(projection.resetsOn)}`,
-  ].filter(Boolean).join(' · ');
-
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`${projection.card.name}, ${rewardValue}${rewardDetail ? ` ${rewardDetail}` : ''}, ${cardContext}`}
-      accessibilityHint="Opens card details"
+      accessibilityLabel={`${projection.card.name}, Add an earning rate`}
+      accessibilityHint={`Opens details for ${projection.card.name}`}
       style={({ pressed }) => [
-        styles.earningsRow,
+        styles.setupRow,
         showDivider && styles.rowDivider,
         pressed && styles.pressed,
       ]}
     >
-      <View style={styles.earningsCopy} accessibilityElementsHidden>
-        <Headline numberOfLines={2}>{projection.card.name}</Headline>
-        <Footnote color="secondary">{cardContext}</Footnote>
+      <View style={styles.rowCopy} accessibilityElementsHidden>
+        <Headline>{projection.card.name}</Headline>
+        <Footnote color="secondary">Add an earning rate</Footnote>
       </View>
-      <View style={styles.earningsValue} accessibilityElementsHidden>
-        <Headline color={isUnconfigured ? 'secondary' : 'primary'} style={styles.tabular}>
-          {rewardValue}
-        </Headline>
-        {rewardDetail ? <Footnote color="secondary">{rewardDetail}</Footnote> : null}
-      </View>
-      <SymbolView
-        name="chevron.right"
-        size={11}
-        tintColor={semanticColors.tertiaryLabel}
-        accessibilityElementsHidden
-      />
     </Pressable>
   );
 }
 
-function CategoryEarningsRow({
+function categorySpendOperationalState(
+  item: PortfolioRewardCategory,
+  formatting: CardFormatting,
+): {
+  label: string;
+  color: 'secondary' | 'attention' | 'destructive';
+} | undefined {
+  const { category } = item;
+  if (category.excluded) {
+    return { label: 'Excluded', color: 'secondary' };
+  }
+  if (category.maximum.reached) {
+    return { label: 'Cap reached', color: 'destructive' };
+  }
+  if ((category.maximum.progress ?? 0) >= 0.8) {
+    return {
+      label: `${thresholdCurrency(category.maximum.remaining ?? 0, formatting)} cap room`,
+      color: 'attention',
+    };
+  }
+  // Card minimums are already communicated on the relevant Keep using row.
+  if (category.blockedByCardMinimum) {
+    return undefined;
+  }
+  if (category.minimum.target !== null && category.minimum.met === false) {
+    return {
+      label: `${thresholdCurrency(category.minimum.remaining ?? 0, formatting)} more to meet tier minimum`,
+      color: 'attention',
+    };
+  }
+  if (category.maximum.target !== null) {
+    return {
+      label: `${thresholdCurrency(category.maximum.remaining ?? 0, formatting)} cap room`,
+      color: 'secondary',
+    };
+  }
+  return undefined;
+}
+
+function CategorySpendRow({
   item,
   formatting,
   onPress,
@@ -188,22 +232,25 @@ function CategoryEarningsRow({
   onPress: () => void;
   showDivider: boolean;
 }) {
-  const rewardValue = item.category.reward.type === 'cashback'
-    ? formatting.currencyExact(item.category.reward.amount)
-    : `${formatting.number(item.category.reward.amount)} miles`;
-  const rewardDetail = item.category.reward.type === 'cashback'
-    ? 'cashback'
-    : `≈ ${formatting.currencyExact(item.category.reward.dollars)}`;
-  const context = `${compactCardName(item.card.card.name)} · ${formatting.currencyCompact(item.category.spend.total)} spent`;
+  const rateLabel = categoryRateLabel(item, formatting);
+  const spendLabel = `${decisionCurrency(item.category.spend.total, formatting)} spent`;
+  const operationalState = categorySpendOperationalState(item, formatting);
+  const context = `${compactCardName(item.card.card.name)}, ${rateLabel}`;
 
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`${item.category.name}, ${item.card.card.name}, ${rewardValue} ${rewardDetail}, ${formatting.currencyCompact(item.category.spend.total)} spent`}
+      accessibilityLabel={[
+        item.category.name,
+        item.card.card.name,
+        rateLabel,
+        spendLabel,
+        operationalState?.label,
+      ].filter(Boolean).join(', ')}
       accessibilityHint={`Opens the ${item.category.name} reward tier on ${item.card.card.name}`}
       style={({ pressed }) => [
-        styles.earningsRow,
+        styles.categoryRow,
         showDivider && styles.rowDivider,
         pressed && styles.pressed,
       ]}
@@ -212,35 +259,22 @@ function CategoryEarningsRow({
         name="flag.fill"
         size={15}
         tintColor={flagColor(item.category.flagColor)}
-        style={styles.flagIcon}
+        style={styles.categoryFlagIcon}
         accessibilityElementsHidden
       />
-      <View style={styles.earningsCopy} accessibilityElementsHidden>
-        <Headline numberOfLines={2}>{item.category.name}</Headline>
+      <View style={styles.rowCopy} accessibilityElementsHidden>
+        <Headline>{item.category.name}</Headline>
         <Footnote color="secondary">{context}</Footnote>
+        <Headline style={styles.tabular}>{spendLabel}</Headline>
+        {operationalState ? (
+          <Footnote color={operationalState.color} style={styles.tabular}>
+            {operationalState.label}
+          </Footnote>
+        ) : null}
       </View>
-      <View style={styles.earningsValue} accessibilityElementsHidden>
-        <Headline style={styles.tabular}>{rewardValue}</Headline>
-        <Footnote color="secondary">{rewardDetail}</Footnote>
-      </View>
-      <SymbolView
-        name="chevron.right"
-        size={11}
-        tintColor={semanticColors.tertiaryLabel}
-        accessibilityElementsHidden
-      />
     </Pressable>
   );
 }
-
-const attentionPriority: Record<CardDashboardProjection['status'], number> = {
-  capped: 0,
-  near_cap: 1,
-  building: 2,
-  unconfigured: 3,
-  earning: 4,
-  open: 5,
-};
 
 export default function OverviewScreen() {
   const router = useRouter();
@@ -248,80 +282,48 @@ export default function OverviewScreen() {
   const model = useRewardsDashboard();
   const formatting = useMemo(() => createCardFormatting(state.settings), [state.settings]);
 
-  const visibleTotals = useMemo(
-    () => model.visibleCards.reduce(
-      (totals, projection) => {
-        totals.value += projection.reward.dollars;
-        totals.cashback += projection.reward.type === 'cashback' ? projection.reward.amount : 0;
-        totals.miles += projection.reward.type === 'miles' ? projection.reward.amount : 0;
-        totals.milesValue += projection.reward.type === 'miles' ? projection.reward.dollars : 0;
-        return totals;
-      },
-      {
-        value: 0,
-        cashback: 0,
-        miles: 0,
-        milesValue: 0,
-      },
-    ),
+  const nonCappedCards = useMemo(
+    () => model.visibleCards.filter((projection) => projection.status !== 'capped'),
     [model.visibleCards],
   );
-
+  const cardUses = useMemo(
+    () => rankCardUses(nonCappedCards, state.settings),
+    [nonCappedCards, state.settings],
+  );
+  const setupCards = useMemo(
+    () => nonCappedCards.filter((projection) => projection.status === 'unconfigured'),
+    [nonCappedCards],
+  );
   const rewardCategories = useMemo(
-    () => collectRewardCategories(model.visibleCards),
-    [model.visibleCards],
+    () => collectRewardCategories(nonCappedCards),
+    [nonCappedCards],
   );
   const categoryPreview = useMemo(
     () => rankRewardCategoryPreview(rewardCategories),
     [rewardCategories],
   );
-  const tierAttentionPreview = useMemo(
-    () => rankRewardCategoryPreview(rewardCategories, rewardCategories.length)
-      .filter(({ category }) => (
-        !category.excluded &&
-        !category.blockedByCardMinimum &&
-        (
-          category.maximum.reached ||
-          (category.maximum.progress ?? 0) >= 0.8 ||
-          (category.minimum.target !== null && category.minimum.met === false)
-        )
-      ))
-      .slice(0, 3),
-    [rewardCategories],
-  );
-  const earnedCategoryPreview = useMemo(
-    () => rankRewardCategoryEarnings(rewardCategories),
-    [rewardCategories],
-  );
-  const attentionCards = useMemo(
-    () => [...model.attentionCards].sort(
-      (left, right) => attentionPriority[left.status] - attentionPriority[right.status],
-    ),
-    [model.attentionCards],
-  );
-  const nativeRewardSummary = [
-    visibleTotals.cashback > 0
-      ? `${formatting.currencyExact(visibleTotals.cashback)} cashback`
-      : undefined,
-    visibleTotals.miles > 0
-      ? `${formatting.number(visibleTotals.miles)} miles ≈ ${formatting.currencyExact(visibleTotals.milesValue)}`
-      : undefined,
-  ].filter(Boolean).join(' · ');
-  const attentionCount = attentionCards.length + tierAttentionPreview.length;
+  const syncActionLabel = model.canSync
+    ? `${model.syncLabel} — Retry`
+    : `${model.syncLabel} — Review settings`;
+  const connected = Boolean(state.pat && state.selectedBudget.id);
+  const hasUsableOrSetupCards = cardUses.length > 0 || setupCards.length > 0;
 
   const openCard = (id: string) => {
     router.push({ pathname: '/card/[id]', params: { id } });
   };
 
+  const openCardUse = (item: RankedCardUse) => {
+    router.push({
+      pathname: '/card/[id]',
+      params: item.use.categoryId
+        ? { id: item.card.card.id, categoryId: item.use.categoryId }
+        : { id: item.card.card.id },
+    });
+  };
+
   const openRewardCategory = (id: string, categoryId: string) => {
     router.push({ pathname: '/card/[id]', params: { id, categoryId } });
   };
-
-  const openRewardCategories = () => {
-    router.push('/(tabs)/overview/categories');
-  };
-
-  const canShowDashboard = state.cards.length > 0 && model.visibleCards.length > 0;
 
   return (
     <ScrollView
@@ -339,10 +341,30 @@ export default function OverviewScreen() {
         />
       )}
     >
-      <LargeNavigationTitle style={styles.navigationTitle}>
-        Overview
-      </LargeNavigationTitle>
-      {!state.pat || !state.selectedBudget.id ? (
+      <View style={styles.top}>
+        <LargeNavigationTitle style={styles.navigationTitle}>
+          Overview
+        </LargeNavigationTitle>
+        {connected && state.cards.length > 0 &&
+        (model.syncState === 'offline' || model.syncState === 'attention') ? (
+          <Pressable
+            onPress={model.canSync ? model.refresh : () => router.push('/settings')}
+            accessibilityRole="button"
+            accessibilityLabel={syncActionLabel}
+            accessibilityHint={model.canSync
+              ? 'Retries syncing rewards from YNAB'
+              : 'Opens YNAB connection settings'}
+            style={({ pressed }) => [
+              styles.syncAction,
+              pressed && styles.pressed,
+            ]}
+          >
+            <Footnote color="action">{syncActionLabel}</Footnote>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {!connected ? (
         <EmptyState
           title="Connect YNAB to begin"
           action={{
@@ -360,113 +382,70 @@ export default function OverviewScreen() {
             accessibilityHint: 'Opens tracked account settings',
           }}
         />
-      ) : !canShowDashboard ? (
+      ) : !hasUsableOrSetupCards ? (
         <EmptyState
-          title="No cards on Overview"
+          title="No cards to use right now"
           action={{
-            label: 'View all cards',
+            label: 'View cards',
             onPress: () => router.push('/(tabs)/cards'),
+            accessibilityHint: 'Opens all cards',
           }}
         />
       ) : (
         <>
-          <View style={styles.hero}>
-            <View
-              accessible
-              accessibilityRole="summary"
-              accessibilityLabel={`Estimated reward value ${formatting.currencyExact(visibleTotals.value)} across current card cycles${nativeRewardSummary ? `, ${nativeRewardSummary}` : ''}`}
-            >
-              <LargeTitle style={styles.heroValue} accessible={false}>
-                {formatting.currencyExact(visibleTotals.value)}
-              </LargeTitle>
-              <Body color="secondary" accessible={false}>
-                Estimated value · current card cycles
-              </Body>
-              {nativeRewardSummary ? (
-                <Footnote color="secondary" style={styles.rewardBreakdown} accessible={false}>
-                  {nativeRewardSummary}
-                </Footnote>
-              ) : null}
-            </View>
-            <SyncBadge
-              state={model.syncState}
-              label={model.syncLabel}
-              onPress={model.canSync ? model.refresh : () => router.push('/settings')}
-              accessibilityHint={model.canSync ? 'Refreshes rewards from YNAB' : 'Opens YNAB settings'}
-            />
-          </View>
-
-          {attentionCount > 0 ? (
+          {cardUses.length > 0 ? (
             <View style={styles.section}>
-              <SectionTitle title="Needs attention" />
+              <SectionTitle title="Keep using" />
               <View style={styles.rows}>
-                {attentionCards.map((projection, index) => (
-                  <AttentionCardRow
-                    key={projection.card.id}
-                    projection={projection}
-                    formatting={formatting}
-                    onPress={() => openCard(projection.card.id)}
-                    showDivider={index < attentionCards.length - 1 || tierAttentionPreview.length > 0}
-                  />
-                ))}
-                {tierAttentionPreview.map((item, index) => (
-                  <RewardCategoryRow
+                {cardUses.map((item, index) => (
+                  <CardUseRow
                     key={item.key}
                     item={item}
                     formatting={formatting}
-                    onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
-                    showDivider={index < tierAttentionPreview.length - 1}
+                    onPress={() => openCardUse(item)}
+                    showDivider={index < cardUses.length - 1}
                   />
                 ))}
               </View>
             </View>
           ) : null}
 
-          <View style={styles.section}>
-            <SectionTitle title="Earned by card" />
-            <View style={styles.rows}>
-              {model.visibleCards.map((projection, index) => (
-                <CardEarningsRow
-                  key={projection.card.id}
-                  projection={projection}
-                  formatting={formatting}
-                  onPress={() => openCard(projection.card.id)}
-                  showDivider={index < model.visibleCards.length - 1}
-                />
-              ))}
+          {setupCards.length > 0 ? (
+            <View style={styles.section}>
+              <SectionTitle title="Set up" />
+              <View style={styles.rows}>
+                {setupCards.map((projection, index) => (
+                  <SetupCardRow
+                    key={projection.card.id}
+                    projection={projection}
+                    onPress={() => openCard(projection.card.id)}
+                    showDivider={index < setupCards.length - 1}
+                  />
+                ))}
+              </View>
             </View>
-          </View>
+          ) : null}
 
           {categoryPreview.length > 0 ? (
             <View style={styles.section}>
               <SectionTitle
-                title={earnedCategoryPreview.length > 0 ? 'Earned by category' : 'Reward categories'}
+                title="Category activity"
                 action={{
                   label: 'See all',
-                  onPress: openRewardCategories,
+                  onPress: () => router.push('/(tabs)/overview/categories'),
                   accessibilityHint: 'Opens every reward category on Overview, grouped by card',
                 }}
               />
               <View style={styles.rows}>
-                {earnedCategoryPreview.length > 0
-                  ? earnedCategoryPreview.map((item, index) => (
-                      <CategoryEarningsRow
-                        key={item.key}
-                        item={item}
-                        formatting={formatting}
-                        onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
-                        showDivider={index < earnedCategoryPreview.length - 1}
-                      />
-                    ))
-                  : categoryPreview.map((item, index) => (
-                      <RewardCategoryRow
-                        key={item.key}
-                        item={item}
-                        formatting={formatting}
-                        onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
-                        showDivider={index < categoryPreview.length - 1}
-                      />
-                    ))}
+                {categoryPreview.map((item, index) => (
+                  <CategorySpendRow
+                    key={item.key}
+                    item={item}
+                    formatting={formatting}
+                    onPress={() => openRewardCategory(item.card.card.id, item.category.id)}
+                    showDivider={index < categoryPreview.length - 1}
+                  />
+                ))}
               </View>
             </View>
           ) : null}
@@ -485,24 +464,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: nativeMetrics.screenGutter,
     paddingTop: spacing.md,
     paddingBottom: 120,
-    gap: spacing.xxxl,
+    gap: spacing.xxl,
+  },
+  top: {
+    gap: spacing.sm,
   },
   navigationTitle: {
     marginTop: spacing.sm,
   },
-  hero: {
-    paddingTop: spacing.sm,
-    gap: spacing.md,
-  },
-  heroValue: {
-    fontSize: 44,
-    fontWeight: '700',
-    fontVariant: ['tabular-nums'],
-    letterSpacing: -1.2,
-  },
-  rewardBreakdown: {
-    marginTop: spacing.sm,
-    fontVariant: ['tabular-nums'],
+  syncAction: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    alignSelf: 'flex-start',
+    justifyContent: 'center',
   },
   section: {
     gap: spacing.md,
@@ -513,45 +486,49 @@ const styles = StyleSheet.create({
     backgroundColor: semanticColors.secondarySystemGroupedBackground,
     overflow: 'hidden',
   },
-  attentionRow: {
+  cardUseRow: {
     minHeight: nativeMetrics.minimumTouchTarget,
     paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.lg,
-    gap: spacing.sm,
+    paddingVertical: spacing.md,
   },
-  rowHeading: {
+  setupRow: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
+  categoryRow: {
+    minHeight: nativeMetrics.minimumTouchTarget,
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.md,
-  },
-  rowTitle: {
-    flex: 1,
-  },
-  earningsRow: {
-    minHeight: 72,
-    flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: spacing.md,
     paddingHorizontal: spacing.lg,
     paddingVertical: spacing.md,
   },
-  earningsCopy: {
+  rowCopy: {
     flex: 1,
     minWidth: 0,
     gap: spacing.xs,
   },
-  earningsValue: {
-    flexShrink: 0,
-    maxWidth: 120,
-    alignItems: 'flex-end',
-    gap: spacing.xs,
+  useLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  flexibleText: {
+    flex: 1,
+    minWidth: 0,
   },
   flagIcon: {
     flexShrink: 0,
+    marginTop: 3,
+  },
+  categoryFlagIcon: {
+    flexShrink: 0,
+    marginTop: 2,
   },
   tabular: {
     fontVariant: ['tabular-nums'],
-    textAlign: 'right',
   },
   rowDivider: {
     borderBottomWidth: StyleSheet.hairlineWidth,

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -87,7 +87,10 @@ function cardUseOperationalLabel(
   formatting: CardFormatting,
 ): string | undefined {
   if (item.operational?.kind === 'minimum') {
-    return `${thresholdCurrency(item.operational.remaining, formatting)} more by ${formatResetDate(item.operational.resetsOn)} to unlock`;
+    const category = item.operational.category
+      ? ` on ${item.operational.category}`
+      : '';
+    return `${thresholdCurrency(item.operational.remaining, formatting)} more${category} before ${formatResetDate(item.operational.resetsOn)} to unlock`;
   }
   if (item.operational?.kind === 'cap') {
     return `${thresholdCurrency(item.operational.remaining, formatting)} cap room`;

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -46,9 +46,7 @@ function decisionCurrency(value: number, formatting: CardFormatting): string {
   if (value !== 0 && Math.abs(value) < 1) {
     return formatting.currencyExact(value);
   }
-  return `${formatting.currency} ${new Intl.NumberFormat('en-GB', {
-    maximumFractionDigits: 0,
-  }).format(value)}`;
+  return formatting.currencyRounded(value);
 }
 
 function thresholdCurrency(value: number, formatting: CardFormatting): string {
@@ -130,7 +128,11 @@ function CardUseRow({
         pressed && styles.pressed,
       ]}
     >
-      <View style={styles.rowCopy} accessibilityElementsHidden>
+      <View
+        style={styles.rowCopy}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
         <Headline>{compactCardName(item.card.card.name)}</Headline>
         <View style={styles.useLabelRow}>
           {item.use.flagColor ? (
@@ -174,8 +176,12 @@ function SetupCardRow({
         pressed && styles.pressed,
       ]}
     >
-      <View style={styles.rowCopy} accessibilityElementsHidden>
-        <Headline>{projection.card.name}</Headline>
+      <View
+        style={styles.rowCopy}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <Headline>{compactCardName(projection.card.name)}</Headline>
         <Footnote color="secondary">Add an earning rate</Footnote>
       </View>
     </Pressable>
@@ -262,7 +268,11 @@ function CategorySpendRow({
         style={styles.categoryFlagIcon}
         accessibilityElementsHidden
       />
-      <View style={styles.rowCopy} accessibilityElementsHidden>
+      <View
+        style={styles.rowCopy}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
         <Headline>{item.category.name}</Headline>
         <Footnote color="secondary">{context}</Footnote>
         <Headline style={styles.tabular}>{spendLabel}</Headline>

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -3,7 +3,6 @@ import {
   RefreshControl,
   ScrollView,
   StyleSheet,
-  useWindowDimensions,
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
@@ -19,7 +18,6 @@ import {
 } from '@/components/native';
 import {
   Body,
-  Caption1,
   LargeTitle,
 } from '@/components/ios';
 import {
@@ -84,8 +82,6 @@ function CardProjectionRow({
 
 export default function OverviewScreen() {
   const router = useRouter();
-  const { fontScale } = useWindowDimensions();
-  const usesStackedHeroHeading = fontScale >= 1.3;
   const { state } = useStorage();
   const model = useRewardsDashboard();
   const formatting = useMemo(() => createCardFormatting(state.settings), [state.settings]);
@@ -191,20 +187,12 @@ export default function OverviewScreen() {
       ) : (
         <>
           <View style={styles.hero}>
-            <View style={[
-              styles.heroHeading,
-              usesStackedHeroHeading && styles.heroHeadingStacked,
-            ]}>
-              <Caption1 color="secondary" style={styles.eyebrow}>
-                CURRENT PERIODS
-              </Caption1>
-              <SyncBadge
-                state={model.syncState}
-                label={model.syncLabel}
-                onPress={model.canSync ? model.refresh : () => router.push('/settings')}
-                accessibilityHint={model.canSync ? 'Refreshes rewards from YNAB' : 'Opens YNAB settings'}
-              />
-            </View>
+            <SyncBadge
+              state={model.syncState}
+              label={model.syncLabel}
+              onPress={model.canSync ? model.refresh : () => router.push('/settings')}
+              accessibilityHint={model.canSync ? 'Refreshes rewards from YNAB' : 'Opens YNAB settings'}
+            />
 
             <View accessible accessibilityRole="summary" accessibilityLabel={`Estimated reward value ${formatting.currencyExact(visibleTotals.value)}`}>
               <LargeTitle style={styles.heroValue} accessible={false}>
@@ -324,21 +312,6 @@ const styles = StyleSheet.create({
   hero: {
     paddingTop: spacing.sm,
     gap: spacing.xl,
-  },
-  heroHeading: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    columnGap: spacing.lg,
-  },
-  heroHeadingStacked: {
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-  },
-  eyebrow: {
-    letterSpacing: 0.7,
-    fontWeight: '600',
   },
   heroValue: {
     fontSize: 44,

--- a/apps/mobile/app/(tabs)/preferences/index.tsx
+++ b/apps/mobile/app/(tabs)/preferences/index.tsx
@@ -2,11 +2,9 @@ import { useCallback, useMemo } from 'react';
 import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 
-import { BrandMark } from '@/components/brand';
-import { Card, SectionHeader, Title2 } from '@/components/ios';
+import { Card, SectionHeader } from '@/components/ios';
 import {
   LargeNavigationTitle,
-  StatusPill,
   SyncBadge,
 } from '@/components/native';
 import { useStorage } from '@/contexts/StorageContext';
@@ -78,39 +76,38 @@ export default function PreferencesScreen() {
       automaticallyAdjustsScrollIndicatorInsets
     >
       <LargeNavigationTitle>Settings</LargeNavigationTitle>
-      <View style={styles.identity} accessible accessibilityLabel="Rewards Tracker">
-        <BrandMark width={44} height={44} />
-        <View style={styles.identityCopy}>
-          <Title2>Rewards Tracker</Title2>
-        </View>
-      </View>
 
       <View>
         <SectionHeader>YNAB</SectionHeader>
         <Card>
           <SettingsRow
             isFirst
-            title={connected ? 'Connected' : 'Connection needed'}
+            title={connected ? state.selectedBudget.name ?? 'YNAB' : 'Connection needed'}
             subtitle={connected
-              ? `${state.selectedBudget.name ?? 'Selected budget'} · ${state.trackedAccountIds.length} card account${state.trackedAccountIds.length === 1 ? '' : 's'}`
+              ? `${state.trackedAccountIds.length} card account${state.trackedAccountIds.length === 1 ? '' : 's'}`
               : 'Connect a Personal Access Token and choose card accounts.'}
             symbol={connected ? 'checkmark.shield.fill' : 'exclamationmark.triangle.fill'}
             symbolColor={connected ? semanticColors.positive : semanticColors.attention}
-            trailing={<StatusPill label={connected ? 'Secure' : 'Setup'} tone={connected ? 'positive' : 'attention'} size="small" />}
           />
-          <SettingsRow
-            title="Last YNAB refresh"
-            subtitle={`Updated ${relativeTime(lastYnabSync).toLowerCase()}`}
-            symbol="arrow.triangle.2.circlepath"
-            trailingIsInteractive
-            trailing={(
-              <SyncBadge
-                state={ynabSyncState}
-                onPress={() => void refreshYnab()}
-                accessibilityHint="Refreshes cards and transactions from YNAB"
-              />
-            )}
-          />
+          {ynabSyncState !== 'synced' ? (
+            <SettingsRow
+              title="Last YNAB refresh"
+              subtitle={`Updated ${relativeTime(lastYnabSync).toLowerCase()}`}
+              symbol="arrow.triangle.2.circlepath"
+              trailingIsInteractive
+              trailing={(
+                <SyncBadge
+                  state={ynabSyncState}
+                  onPress={connected
+                    ? () => void refreshYnab()
+                    : () => router.push('/settings')}
+                  accessibilityHint={connected
+                    ? 'Refreshes cards and transactions from YNAB'
+                    : 'Opens YNAB connection settings'}
+                />
+              )}
+            />
+          ) : null}
           <SettingsRow
             title="Manage connection"
             subtitle="Budget, token and tracked accounts"
@@ -187,14 +184,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.xl,
     paddingBottom: 48,
     gap: spacing.xxl,
-  },
-  identity: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.lg,
-    paddingVertical: spacing.md,
-  },
-  identityCopy: {
-    flex: 1,
   },
 });

--- a/apps/mobile/app/(tabs)/preferences/index.tsx
+++ b/apps/mobile/app/(tabs)/preferences/index.tsx
@@ -86,8 +86,8 @@ export default function PreferencesScreen() {
             subtitle={connected
               ? `${state.trackedAccountIds.length} card account${state.trackedAccountIds.length === 1 ? '' : 's'}`
               : 'Connect a Personal Access Token and choose card accounts.'}
-            symbol={connected ? 'checkmark.shield.fill' : 'exclamationmark.triangle.fill'}
-            symbolColor={connected ? semanticColors.positive : semanticColors.attention}
+            symbol={connected ? undefined : 'exclamationmark.triangle.fill'}
+            symbolColor={semanticColors.attention}
           />
           {ynabSyncState !== 'synced' ? (
             <SettingsRow

--- a/apps/mobile/app/(tabs)/recommendations.tsx
+++ b/apps/mobile/app/(tabs)/recommendations.tsx
@@ -110,11 +110,9 @@ export default function RecommendationsScreen() {
                     <View style={styles.recommendationContent}>
                       <View style={styles.recommendationHeader}>
                         <Headline>{rec.cardName}</Headline>
-                        <View style={[styles.priorityBadge, styles[`priority${rec.priority}`]]}>
-                          <Caption1 style={styles.priorityBadgeText}>
-                            {rec.priority.toUpperCase()}
-                          </Caption1>
-                        </View>
+                        <Caption1 color="secondary" style={styles.priorityText}>
+                          {rec.priority.charAt(0).toUpperCase() + rec.priority.slice(1)} priority
+                        </Caption1>
                       </View>
                       <Body color="secondary">{rec.reason}</Body>
                       <Footnote style={{ marginTop: 4, fontWeight: '600', color: actionDetails.color }}>
@@ -159,22 +157,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 12,
   },
-  priorityBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 6,
-  },
-  priorityBadgeText: {
-    color: semanticColors.primaryButtonForeground,
+  priorityText: {
+    flexShrink: 0,
     fontWeight: '600',
-  },
-  priorityhigh: {
-    backgroundColor: semanticColors.systemRed,
-  },
-  prioritymedium: {
-    backgroundColor: semanticColors.systemOrange,
-  },
-  prioritylow: {
-    backgroundColor: semanticColors.systemGreen,
   },
 });

--- a/apps/mobile/app/card/[id]/edit.tsx
+++ b/apps/mobile/app/card/[id]/edit.tsx
@@ -518,11 +518,13 @@ function TierEditor({
             <Footnote color="secondary">YNAB {tier.flagColor === 'unflagged' ? 'unflagged' : `${tier.flagColor} flag`}</Footnote>
           </View>
         </View>
-        <StatusPill
-          label={tier.active ? (tier.excludeFromRewards ? 'Excluded' : 'Active') : 'Inactive'}
-          tone={tier.active ? (tier.excludeFromRewards ? 'attention' : 'positive') : 'inactive'}
-          size="small"
-        />
+        {!tier.active || tier.excludeFromRewards ? (
+          <StatusPill
+            label={tier.active ? 'Excluded' : 'Inactive'}
+            tone={tier.active ? 'attention' : 'inactive'}
+            size="small"
+          />
+        ) : null}
       </View>
 
       <TierFlagPicker
@@ -785,18 +787,6 @@ export default function EditCardScreen() {
         options={{
           title: 'Edit card',
           gestureEnabled: !saving,
-          headerRight: () => (
-            <Button
-              variant="plain"
-              size="small"
-              onPress={save}
-              disabled={saving || !form.name.trim()}
-              accessibilityLabel={saving ? 'Saving card' : 'Save card'}
-              style={styles.headerButton}
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </Button>
-          ),
         }}
       />
       <ScrollView
@@ -839,7 +829,6 @@ export default function EditCardScreen() {
             <View style={styles.toggleCopy}>
               <Headline>{accountName ?? sourceCard.name}</Headline>
             </View>
-            <StatusPill label="Linked" tone="positive" size="small" />
           </View>
           <Pressable
             onPress={() => router.push('/settings')}
@@ -999,14 +988,6 @@ export default function EditCardScreen() {
           >
             {saving ? 'Saving…' : 'Save changes'}
           </Button>
-          <Button
-            variant="plain"
-            size="medium"
-            onPress={() => router.back()}
-            disabled={saving}
-          >
-            Cancel
-          </Button>
         </View>
       </ScrollView>
     </KeyboardAvoidingView>
@@ -1032,9 +1013,6 @@ const styles = StyleSheet.create({
     paddingTop: spacing.xl,
     paddingBottom: 60,
     gap: spacing.xxl,
-  },
-  headerButton: {
-    marginHorizontal: -spacing.sm,
   },
   errorBanner: {
     padding: spacing.lg,

--- a/apps/mobile/app/card/[id]/index.tsx
+++ b/apps/mobile/app/card/[id]/index.tsx
@@ -24,7 +24,6 @@ import {
   Footnote,
   Headline,
   LargeTitle,
-  Title2,
   Title3,
 } from '@/components/ios';
 import {
@@ -41,7 +40,6 @@ import {
   formatRate,
   formatRewardForCard,
   formatResetDate,
-  statusPresentation,
   type CardFormatting,
 } from '@/features/cards/presentation';
 import { semanticColors } from '@/theme';
@@ -61,6 +59,16 @@ function formatHiddenUntil(value: string): string {
     day: 'numeric',
     month: 'short',
   }).format(new Date(value));
+}
+
+function removeCardNamePrefix(accountName: string | undefined, cardName: string): string | undefined {
+  if (!accountName) return undefined;
+  const prefix = accountName.slice(0, cardName.length);
+  const suffix = accountName.slice(cardName.length);
+  if (prefix.toLocaleLowerCase() !== cardName.toLocaleLowerCase() || !/^[\s·—–-]/.test(suffix)) {
+    return accountName;
+  }
+  return suffix.replace(/^[\s·—–-]+/, '') || undefined;
 }
 
 function ConfigRow({ label, value, showDivider = true }: {
@@ -207,7 +215,9 @@ function SubcategoryRow({
             </Footnote>
           </View>
         </View>
-        <StatusPill label={stateLabel.label} tone={stateLabel.tone} size="small" accessible={false} />
+        {stateLabel.tone !== 'positive' ? (
+          <StatusPill label={stateLabel.label} tone={stateLabel.tone} size="small" accessible={false} />
+        ) : null}
       </View>
 
       <View style={styles.subcategoryMetrics} accessibilityElementsHidden>
@@ -373,12 +383,25 @@ export default function CardDetailScreen() {
     : hiddenEntry
       ? `Hidden until ${formatHiddenUntil(hiddenEntry.hiddenUntil)}`
       : 'Shown';
-  const overviewPillLabel = card.featured === false
+  const overviewContext = card.featured === false
     ? 'Not on Overview'
     : hiddenEntry
       ? 'Hidden until reset'
-      : 'On Overview';
+      : undefined;
   const accountName = getCardAccountName(card, model.cacheEntry);
+  const accountContext = removeCardNamePrefix(accountName, card.name);
+  const seenIdentityLabels = new Set([card.name.trim().toLocaleLowerCase()]);
+  const identityContext = [
+    card.issuer !== 'Unknown' ? card.issuer : undefined,
+    accountContext,
+    overviewContext,
+  ].filter((value): value is string => {
+    if (!value) return false;
+    const key = value.trim().toLocaleLowerCase();
+    if (seenIdentityLabels.has(key)) return false;
+    seenIdentityLabels.add(key);
+    return true;
+  }).join(' · ');
   const subcategories = [...(card.subcategories ?? [])].sort((left, right) => left.priority - right.priority);
   const blockCopy = projection.blockInfo
     ? [
@@ -395,24 +418,41 @@ export default function CardDetailScreen() {
   const nativeRewardLabel = card.type === 'cashback'
     ? 'cashback earned'
     : `miles earned · ≈ ${formatting.currencyExact(projection.reward.dollars)}`;
+  const earningSetupRows = [
+    { label: 'Reward type', value: card.type === 'cashback' ? 'Cashback' : 'Miles' },
+    { label: 'Rate', value: formatRate(card, formatting) },
+    (card.minimumSpend ?? 0) > 0
+      ? { label: 'Minimum', value: formatting.currencyCompact(card.minimumSpend!) }
+      : undefined,
+    (card.maximumSpend ?? 0) > 0
+      ? { label: 'Cap', value: formatting.currencyCompact(card.maximumSpend!) }
+      : undefined,
+    (card.earningBlockSize ?? 0) > 0
+      ? {
+          label: 'Earning method',
+          value: `${formatting.currencyCompact(card.earningBlockSize!)} transaction blocks`,
+        }
+      : undefined,
+    card.billingCycle?.type === 'billing'
+      ? {
+          label: 'Cycle',
+          value: `Resets monthly after day ${card.billingCycle.dayOfMonth ?? 1}`,
+        }
+      : undefined,
+    card.promotionalPeriod
+      ? {
+          label: 'Promotion',
+          value: `${card.promotionalPeriod.description || 'Active promotion'} · until ${formatResetDate(card.promotionalPeriod.endDate)}`,
+        }
+      : undefined,
+  ].filter((row): row is { label: string; value: string } => Boolean(row));
+  const showsDetailHeading = Boolean(identityContext) || model.syncState !== 'synced';
 
   return (
     <>
       <Stack.Screen
         options={{
-          title: 'Card',
-          headerRight: () => (
-            <Button
-              variant="plain"
-              size="small"
-              onPress={edit}
-              accessibilityLabel={`Edit ${card.name}`}
-              accessibilityHint="Opens card settings"
-              style={styles.headerButton}
-            >
-              Edit
-            </Button>
-          ),
+          title: card.name,
         }}
       />
       <ScrollView
@@ -431,36 +471,23 @@ export default function CardDetailScreen() {
           />
         )}
       >
-        <View style={styles.detailHeading}>
-          <View style={styles.titleRow}>
-            <View style={styles.titleCopy}>
-              <Title2 accessibilityRole="header">{card.name}</Title2>
-              <Footnote color="secondary">
-                {[card.issuer !== 'Unknown' ? card.issuer : undefined, accountName].filter(Boolean).join(' · ')}
-              </Footnote>
-            </View>
-            <StatusPill
-              label={overviewPillLabel}
-              tone={card.featured === false || hiddenEntry ? 'inactive' : 'accent'}
+        {showsDetailHeading ? (
+          <View style={styles.detailHeading}>
+            {identityContext ? (
+              <Footnote color="secondary">{identityContext}</Footnote>
+            ) : null}
+            <SyncBadge
+              state={model.syncState}
+              label={model.syncLabel}
+              onPress={model.canSync ? model.refresh : () => router.push('/settings')}
             />
           </View>
-          <SyncBadge
-            state={model.syncState}
-            label={model.syncLabel}
-            onPress={model.canSync ? model.refresh : () => router.push('/settings')}
-          />
-        </View>
+        ) : null}
 
         <View style={styles.hero}>
-          <View style={styles.heroTopRow}>
-            <View style={styles.heroPeriod}>
-              <Caption1 color="secondary" style={styles.eyebrow}>CURRENT PERIOD</Caption1>
-              <Footnote color="secondary">{formatPeriod(projection.period)}</Footnote>
-            </View>
-            <StatusPill
-              label={statusPresentation(projection.status).label}
-              tone={statusPresentation(projection.status).tone}
-            />
+          <View style={styles.heroPeriod}>
+            <Caption1 color="secondary">Current period</Caption1>
+            <Footnote color="secondary">{formatPeriod(projection.period)}</Footnote>
           </View>
 
           <View
@@ -509,11 +536,11 @@ export default function CardDetailScreen() {
           ) : null}
 
           <View style={styles.heroFooter}>
-            <Headline color={projection.status === 'capped' ? 'destructive' : projection.status === 'near_cap' || projection.status === 'building' || projection.status === 'unconfigured' ? 'attention' : 'positive'}>
-              {projection.status === 'earning' || projection.status === 'open'
-                ? 'Earning is on track.'
-                : attentionCopy(projection, formatting)}
-            </Headline>
+            {projection.status !== 'earning' && projection.status !== 'open' ? (
+              <Headline color={projection.status === 'capped' ? 'destructive' : 'attention'}>
+                {attentionCopy(projection, formatting)}
+              </Headline>
+            ) : null}
             <Footnote color="secondary">
               {formatDaysRemaining(projection.daysRemaining, projection.resetsOn)}
             </Footnote>
@@ -523,18 +550,20 @@ export default function CardDetailScreen() {
 
         <View style={styles.section}>
           <SectionTitle
-            title="Overview & order"
+            title="Card order"
           />
           <View style={styles.overviewControlCard}>
-            <ConfigRow label="Overview" value={overviewLabel} />
+            {card.featured === false || hiddenEntry ? (
+              <ConfigRow label="Overview" value={overviewLabel} />
+            ) : null}
             <ConfigRow
-              label="Card order"
+              label="Position"
               value={orderIndex >= 0 ? `${orderIndex + 1} of ${orderedCards.length}` : 'Not ordered'}
               showDivider={false}
             />
             <View style={styles.orderButtons}>
               <Button
-                variant="tinted"
+                variant="plain"
                 size="small"
                 disabled={orderIndex <= 0}
                 onPress={() => void moveCard(-1)}
@@ -543,7 +572,7 @@ export default function CardDetailScreen() {
                 Move earlier
               </Button>
               <Button
-                variant="tinted"
+                variant="plain"
                 size="small"
                 disabled={orderIndex < 0 || orderIndex >= orderedCards.length - 1}
                 onPress={() => void moveCard(1)}
@@ -568,38 +597,17 @@ export default function CardDetailScreen() {
         <View style={styles.section}>
           <SectionTitle
             title="Earning setup"
-            action={{ label: 'Edit', onPress: edit, accessibilityHint: 'Opens card settings' }}
+            action={{ label: 'Edit card', onPress: edit, accessibilityHint: 'Opens card settings' }}
           />
           <View style={styles.group}>
-            <ConfigRow label="Reward type" value={card.type === 'cashback' ? 'Cashback' : 'Miles'} />
-            <ConfigRow label="Rate" value={formatRate(card, formatting)} />
-            <ConfigRow
-              label="Minimum"
-              value={(card.minimumSpend ?? 0) > 0 ? formatting.currencyCompact(card.minimumSpend!) : 'None'}
-            />
-            <ConfigRow
-              label="Cap"
-              value={(card.maximumSpend ?? 0) > 0 ? formatting.currencyCompact(card.maximumSpend!) : 'None'}
-            />
-            <ConfigRow
-              label="Earning method"
-              value={(card.earningBlockSize ?? 0) > 0
-                ? `${formatting.currencyCompact(card.earningBlockSize!)} transaction blocks`
-                : 'Exact transaction amount'}
-            />
-            <ConfigRow
-              label="Cycle"
-              value={card.billingCycle?.type === 'billing'
-                ? `Resets monthly after day ${card.billingCycle.dayOfMonth ?? 1}`
-                : 'Calendar month'}
-            />
-            <ConfigRow
-              label="Promotion"
-              value={card.promotionalPeriod
-                ? `${card.promotionalPeriod.description || 'Active promotion'} · until ${formatResetDate(card.promotionalPeriod.endDate)}`
-                : 'None'}
-              showDivider={false}
-            />
+            {earningSetupRows.map((row, index) => (
+              <ConfigRow
+                key={row.label}
+                label={row.label}
+                value={row.value}
+                showDivider={index < earningSetupRows.length - 1}
+              />
+            ))}
           </View>
         </View>
 
@@ -700,24 +708,8 @@ const styles = StyleSheet.create({
     paddingBottom: 80,
     gap: spacing.xxxl,
   },
-  headerButton: {
-    marginHorizontal: -spacing.sm,
-  },
   detailHeading: {
     gap: spacing.md,
-  },
-  titleRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    columnGap: spacing.lg,
-    rowGap: spacing.sm,
-  },
-  titleCopy: {
-    flex: 1,
-    minWidth: 200,
-    gap: spacing.xs,
   },
   hero: {
     marginHorizontal: -spacing.xs,
@@ -727,20 +719,8 @@ const styles = StyleSheet.create({
     borderRadius: radii.xlarge,
     backgroundColor: semanticColors.secondarySystemGroupedBackground,
   },
-  heroTopRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-    columnGap: spacing.lg,
-    rowGap: spacing.sm,
-  },
   heroPeriod: {
     gap: spacing.xs,
-  },
-  eyebrow: {
-    letterSpacing: 0.7,
-    fontWeight: '600',
   },
   rewardValue: {
     fontSize: 42,

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -378,7 +378,12 @@ export default function SettingsScreen() {
       return 'Token verified. Select a budget and at least one account, then tap Finish setup.';
     }
     if (isConnected) {
-      return isSetupMode ? 'Connected. Choose a budget below to continue.' : null;
+      if (!isSetupMode) {
+        return null;
+      }
+      return state.selectedBudget.id
+        ? 'Connected. Choose at least one account below to continue.'
+        : 'Connected. Choose a budget below to continue.';
     }
     return null;
   })();

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -12,6 +12,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useRouter } from 'expo-router';
+import { SymbolView } from 'expo-symbols';
 import { useHaptics } from '@/hooks/useHaptics';
 import { useToast } from '@/contexts/ToastContext';
 import { Card, ListItem, Button, Footnote, SectionHeader, Separator, Headline, Caption1 } from '@/components/ios';
@@ -21,13 +22,13 @@ import type { YnabAccountSummary, YnabBudgetSummary } from '@/lib/ynab-client';
 
 const connectionStatusCopy: Record<
   'disconnected' | 'authenticating' | 'awaiting_budget' | 'connected' | 'error',
-  { label: string; tone: 'primary' | 'secondary' | 'danger' }
+  string
 > = {
-  disconnected: { label: 'Disconnected', tone: 'secondary' },
-  authenticating: { label: 'Connecting…', tone: 'primary' },
-  awaiting_budget: { label: 'Awaiting budget selection', tone: 'primary' },
-  connected: { label: 'Connected', tone: 'primary' },
-  error: { label: 'Connection error', tone: 'danger' },
+  disconnected: 'Disconnected',
+  authenticating: 'Connecting…',
+  awaiting_budget: 'Awaiting budget selection',
+  connected: 'Connected',
+  error: 'Connection error',
 };
 
 export default function SettingsScreen() {
@@ -377,7 +378,7 @@ export default function SettingsScreen() {
       return 'Token verified. Select a budget and at least one account, then tap Finish setup.';
     }
     if (isConnected) {
-      return isSetupMode ? 'Connected. Choose a budget below to continue.' : 'Connected.';
+      return isSetupMode ? 'Connected. Choose a budget below to continue.' : null;
     }
     return null;
   })();
@@ -413,8 +414,7 @@ export default function SettingsScreen() {
                 <View style={styles.fieldGroup}>
                   <Footnote color="secondary">Status</Footnote>
                   <View style={styles.statusRow}>
-                    <View style={[styles.statusDot, styles[`statusDot_${statusMeta.tone}`]]} />
-                    <Headline>{statusMeta.label}</Headline>
+                    <Headline>{statusMeta}</Headline>
                     {(isAuthenticating || isSyncing) ? (
                       <ActivityIndicator size="small" color={semanticHex.systemBlue} />
                     ) : null}
@@ -590,11 +590,15 @@ export default function SettingsScreen() {
                               <Headline>{account.name}</Headline>
                               <Caption1 color="secondary">{formatAccountType(account.type)}</Caption1>
                             </View>
-                            <View style={[styles.trackBadge, trackedAccounts.includes(account.id) && styles.trackBadgeActive]}>
-                              <Caption1 color={trackedAccounts.includes(account.id) ? 'primary' : 'secondary'}>
-                                {trackedAccounts.includes(account.id) ? 'Tracking' : 'Track'}
-                              </Caption1>
-                            </View>
+                            {trackedAccounts.includes(account.id) ? (
+                              <SymbolView
+                                name="checkmark"
+                                size={17}
+                                weight="semibold"
+                                tintColor={semanticColors.action}
+                                accessibilityElementsHidden
+                              />
+                            ) : null}
                           </View>
                         </ListItem>
                       </React.Fragment>
@@ -657,21 +661,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
-  },
-  statusDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    backgroundColor: semanticColors.separator,
-  },
-  statusDot_primary: {
-    backgroundColor: semanticColors.systemBlue,
-  },
-  statusDot_secondary: {
-    backgroundColor: semanticColors.systemGray2,
-  },
-  statusDot_danger: {
-    backgroundColor: semanticColors.systemRed,
   },
   statusError: {
     color: semanticColors.systemRed,
@@ -746,15 +735,6 @@ const styles = StyleSheet.create({
   accountInfo: {
     flex: 1,
     gap: 4,
-  },
-  trackBadge: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 999,
-    backgroundColor: semanticColors.secondarySystemFill,
-  },
-  trackBadgeActive: {
-    backgroundColor: withAlpha(semanticHex.systemBlue, '22'),
   },
   doneButton: {
     paddingHorizontal: 8,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "ios": "pnpm exec expo run:ios",
     "android": "pnpm exec expo start --android",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "vitest run src/storage/service.test.ts src/features/activity/flag-update.integration.test.ts src/features/activity/flag-update.test.ts src/features/cards/card-edit-publication.integration.test.ts src/features/cards/card-edit-refresh.test.ts src/features/cards/local-day-clock.test.ts src/contexts/setup-sync-chain.test.ts src/lib/cloud-sync-key.test.ts src/lib/cloud-sync-revision.test.ts"
+    "test": "vitest run src/storage/service.test.ts src/features/activity/flag-update.integration.test.ts src/features/activity/flag-update.test.ts src/features/cards/card-edit-publication.integration.test.ts src/features/cards/card-edit-refresh.test.ts src/features/cards/local-day-clock.test.ts src/features/cards/reward-categories.test.ts src/contexts/setup-sync-chain.test.ts src/lib/cloud-sync-key.test.ts src/lib/cloud-sync-revision.test.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.25.0",

--- a/apps/mobile/src/components/native/CardStatusRow.tsx
+++ b/apps/mobile/src/components/native/CardStatusRow.tsx
@@ -114,6 +114,9 @@ export function CardStatusRow({
   const groupsAccessibilityContent = Boolean(onPress);
   const resolvedStatus = resolveStatus(status, spend, minimumSpend, maximumSpend);
   const context = joinContext(issuer, periodLabel);
+  const showsStatus = resolvedStatus.tone === 'attention' ||
+    resolvedStatus.tone === 'capped' ||
+    resolvedStatus.tone === 'inactive';
   const hasMinimum = isPositiveThreshold(minimumSpend);
   const hasMaximum = isPositiveThreshold(maximumSpend);
 
@@ -150,12 +153,14 @@ export function CardStatusRow({
         </View>
 
         <View style={styles.trailing}>
-          <StatusPill
-            label={resolvedStatus.label}
-            tone={resolvedStatus.tone}
-            size="small"
-            accessible={!groupsAccessibilityContent}
-          />
+          {showsStatus ? (
+            <StatusPill
+              label={resolvedStatus.label}
+              tone={resolvedStatus.tone}
+              size="small"
+              accessible={!groupsAccessibilityContent}
+            />
+          ) : null}
           {onPress ? (
             <Body color="tertiary" accessible={false} style={styles.disclosure}>
               {'\u203A'}

--- a/apps/mobile/src/components/native/ProgressRail.tsx
+++ b/apps/mobile/src/components/native/ProgressRail.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 import { Caption1 } from '../ios/Typography';
-import { SparkIcon } from '../brand';
 import { semanticColors } from '../../theme/semanticColors';
 import { nativeMetrics, radii, spacing } from '../../theme/tokens';
 
@@ -13,7 +12,6 @@ export interface ProgressRailProps {
   label?: string;
   formatValue?: (value: number) => string;
   showLegend?: boolean;
-  showSpark?: boolean;
   accessible?: boolean;
   style?: StyleProp<ViewStyle>;
 }
@@ -29,8 +27,7 @@ function defaultFormatValue(value: number): string {
 }
 
 /**
- * A single spend rail with explicit minimum and cap semantics. The gold spark
- * is only the current-position terminal; capped state switches to system red.
+ * A single spend rail with explicit minimum and cap semantics.
  */
 export function ProgressRail({
   value,
@@ -39,7 +36,6 @@ export function ProgressRail({
   label = 'Spend progress',
   formatValue = defaultFormatValue,
   showLegend = true,
-  showSpark = true,
   accessible = true,
   style,
 }: ProgressRailProps) {
@@ -120,11 +116,6 @@ export function ProgressRail({
           <View style={[styles.capMarker, capped && styles.cappedMarker]} />
         ) : null}
 
-        {showSpark && progressPercent > 1 ? (
-          <View style={[styles.sparkTerminal, { left: `${progressPercent}%` }]}>
-            <SparkIcon width={14} height={14} />
-          </View>
-        ) : null}
       </View>
 
       {showLegend && (hasMinimum || hasMaximum) ? (
@@ -197,13 +188,6 @@ const styles = StyleSheet.create({
   },
   cappedMarker: {
     backgroundColor: semanticColors.capped,
-  },
-  sparkTerminal: {
-    position: 'absolute',
-    top: -3,
-    width: 14,
-    height: 14,
-    marginLeft: -7,
   },
   legend: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/native/StatusPill.tsx
+++ b/apps/mobile/src/components/native/StatusPill.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
-import { Caption1, Caption2 } from '../ios/Typography';
+import { Caption1, Footnote } from '../ios/Typography';
 import { semanticColors } from '../../theme/semanticColors';
-import { radii, spacing } from '../../theme/tokens';
 
 export type StatusTone =
   | 'neutral'
@@ -16,7 +15,6 @@ export interface StatusPillProps {
   label: string;
   tone?: StatusTone;
   size?: 'small' | 'regular';
-  showDot?: boolean;
   accessible?: boolean;
   accessibilityLabel?: string;
   style?: StyleProp<ViewStyle>;
@@ -26,55 +24,40 @@ export interface StatusPillProps {
 function toneStyles(tone: StatusTone) {
   switch (tone) {
     case 'accent':
-      return [styles.accentContainer, styles.accentDot, styles.accentText] as const;
+      return styles.accentText;
     case 'positive':
-      return [styles.positiveContainer, styles.positiveDot, styles.positiveText] as const;
+      return styles.positiveText;
     case 'attention':
-      return [styles.attentionContainer, styles.attentionDot, styles.attentionText] as const;
+      return styles.attentionText;
     case 'capped':
-      return [styles.cappedContainer, styles.cappedDot, styles.cappedText] as const;
+      return styles.cappedText;
     case 'inactive':
-      return [styles.inactiveContainer, styles.inactiveDot, styles.inactiveText] as const;
+      return styles.inactiveText;
     case 'neutral':
-      return [styles.neutralContainer, styles.neutralDot, styles.neutralText] as const;
+      return styles.neutralText;
   }
 }
 
-/** Compact, non-interactive status with redundant shape, text, and colour cues. */
+/** Quiet, non-interactive status text. Reserve colour for states that need attention. */
 export function StatusPill({
   label,
   tone = 'neutral',
   size = 'regular',
-  showDot = true,
   accessible = true,
   accessibilityLabel,
   style,
   textStyle,
 }: StatusPillProps) {
-  const [containerTone, dotTone, textTone] = toneStyles(tone);
-  const Label = size === 'small' ? Caption2 : Caption1;
+  const textTone = toneStyles(tone);
+  const Label = size === 'small' ? Caption1 : Footnote;
 
   return (
     <View
-      style={[
-        styles.container,
-        size === 'small' ? styles.smallContainer : styles.regularContainer,
-        containerTone,
-        style,
-      ]}
+      style={[styles.container, style]}
       accessible={accessible}
       accessibilityRole={accessible ? 'text' : undefined}
       accessibilityLabel={accessible ? accessibilityLabel ?? label : undefined}
     >
-      {showDot ? (
-        <View
-          style={[
-            styles.dot,
-            size === 'small' && styles.smallDot,
-            dotTone,
-          ]}
-        />
-      ) : null}
       <Label
         accessible={false}
         style={[styles.label, textTone, textStyle]}
@@ -88,94 +71,26 @@ export function StatusPill({
 const styles = StyleSheet.create({
   container: {
     alignSelf: 'flex-start',
-    flexDirection: 'row',
-    alignItems: 'center',
     maxWidth: '100%',
-    borderRadius: radii.pill,
-    borderWidth: StyleSheet.hairlineWidth,
-  },
-  regularContainer: {
-    minHeight: 26,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    gap: 6,
-  },
-  smallContainer: {
-    minHeight: 22,
-    paddingHorizontal: 7,
-    paddingVertical: 3,
-    gap: spacing.xs,
   },
   label: {
     flexShrink: 1,
     fontWeight: '600',
   },
-  dot: {
-    width: 7,
-    height: 7,
-    borderRadius: radii.pill,
-    flexShrink: 0,
-  },
-  smallDot: {
-    width: 6,
-    height: 6,
-  },
-  neutralContainer: {
-    backgroundColor: semanticColors.neutralTint,
-    borderColor: semanticColors.separator,
-  },
-  neutralDot: {
-    backgroundColor: semanticColors.systemGray,
-  },
   neutralText: {
     color: semanticColors.secondaryLabel,
   },
-  accentContainer: {
-    backgroundColor: semanticColors.actionTint,
-    borderColor: semanticColors.action,
-  },
-  accentDot: {
-    backgroundColor: semanticColors.action,
-  },
   accentText: {
-    color: semanticColors.action,
-  },
-  positiveContainer: {
-    backgroundColor: semanticColors.positiveTint,
-    borderColor: semanticColors.positive,
-  },
-  positiveDot: {
-    backgroundColor: semanticColors.positive,
+    color: semanticColors.secondaryLabel,
   },
   positiveText: {
-    color: semanticColors.positive,
-  },
-  attentionContainer: {
-    backgroundColor: semanticColors.attentionTint,
-    borderColor: semanticColors.attention,
-  },
-  attentionDot: {
-    backgroundColor: semanticColors.attention,
+    color: semanticColors.secondaryLabel,
   },
   attentionText: {
     color: semanticColors.attention,
   },
-  cappedContainer: {
-    backgroundColor: semanticColors.destructiveTint,
-    borderColor: semanticColors.capped,
-  },
-  cappedDot: {
-    backgroundColor: semanticColors.capped,
-  },
   cappedText: {
     color: semanticColors.capped,
-  },
-  inactiveContainer: {
-    backgroundColor: semanticColors.neutralTint,
-    borderColor: semanticColors.separator,
-  },
-  inactiveDot: {
-    backgroundColor: semanticColors.systemGray2,
   },
   inactiveText: {
     color: semanticColors.tertiaryLabel,

--- a/apps/mobile/src/components/native/SyncBadge.tsx
+++ b/apps/mobile/src/components/native/SyncBadge.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ReactElement } from 'react';
 import { Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import { interaction, nativeMetrics } from '../../theme/tokens';
 import { StatusPill, type StatusTone } from './StatusPill';
@@ -29,7 +29,11 @@ export function SyncBadge({
   accessibilityLabel,
   accessibilityHint,
   style,
-}: SyncBadgeProps) {
+}: SyncBadgeProps): ReactElement | null {
+  if (state === 'synced') {
+    return null;
+  }
+
   const presentation = statePresentation[state];
   const resolvedLabel = label ?? presentation.label;
   const badge = (

--- a/apps/mobile/src/features/cards/presentation.ts
+++ b/apps/mobile/src/features/cards/presentation.ts
@@ -15,6 +15,7 @@ export interface CardFormatting {
   currency: string;
   currencyCompact: (value: number) => string;
   currencyExact: (value: number) => string;
+  currencyRounded: (value: number) => string;
   number: (value: number) => string;
 }
 
@@ -33,6 +34,11 @@ export function createCardFormatting(settings: AppSettings): CardFormatting {
       locale,
       currency,
       decimals: 2,
+    }),
+    currencyRounded: (value) => formatCurrencyCore(value, {
+      locale,
+      currency,
+      decimals: 0,
     }),
     number: (value) => new Intl.NumberFormat(locale, {
       maximumFractionDigits: Number.isInteger(value) ? 0 : 2,

--- a/apps/mobile/src/features/cards/presentation.ts
+++ b/apps/mobile/src/features/cards/presentation.ts
@@ -166,19 +166,13 @@ export function formatThresholdSummary(
   card: CreditCard,
   formatting: CardFormatting,
 ): string {
-  const values = [
-    card.featured === false ? 'Not on Overview' : 'On Overview',
-    formatRate(card, formatting),
-  ];
+  const values = card.featured === false ? ['Not on Overview'] : [];
+  values.push(formatRate(card, formatting));
   if (typeof card.minimumSpend === 'number' && card.minimumSpend > 0) {
     values.push(`Min ${formatting.currencyCompact(card.minimumSpend)}`);
-  } else {
-    values.push('No minimum');
   }
   if (typeof card.maximumSpend === 'number' && card.maximumSpend > 0) {
     values.push(`Cap ${formatting.currencyCompact(card.maximumSpend)}`);
-  } else {
-    values.push('No cap');
   }
   if (typeof card.earningBlockSize === 'number' && card.earningBlockSize > 0) {
     values.push(`${formatting.currencyCompact(card.earningBlockSize)} blocks`);

--- a/apps/mobile/src/features/cards/reward-categories.test.ts
+++ b/apps/mobile/src/features/cards/reward-categories.test.ts
@@ -50,7 +50,13 @@ describe('rankCardUses', () => {
     expect(uses).toEqual([]);
   });
 
-  it('omits a block card when its remaining room cannot fit another block', () => {
+  it.each([
+    { remaining: 5, expected: true },
+    { remaining: 2, expected: false },
+  ])('keeps a block card only when a whole block fits with $remaining room', ({
+    remaining,
+    expected,
+  }) => {
     const { dashboard, fixture } = demoDashboard();
     const orbit = dashboard.cards.find((item) => item.card.id === 'demo-card-orbit');
     expect(orbit).toBeDefined();
@@ -61,12 +67,12 @@ describe('rankCardUses', () => {
       maximum: {
         ...orbit!.maximum,
         target: 1_000,
-        remaining: 2,
+        remaining,
         reached: false,
       },
     }], fixture.settings);
 
-    expect(uses).toEqual([]);
+    expect(uses.length > 0).toBe(expected);
   });
 
   it.each([

--- a/apps/mobile/src/features/cards/reward-categories.test.ts
+++ b/apps/mobile/src/features/cards/reward-categories.test.ts
@@ -75,32 +75,63 @@ describe('rankCardUses', () => {
     expect(uses.length > 0).toBe(expected);
   });
 
-  it.each([
-    { room: 100, expected: true },
-    { room: 80, expected: true },
-    { room: 79, expected: false },
-  ])('includes a near-cap minimum only when it is reachable with $room room', ({
-    room,
-    expected,
-  }) => {
+  it.each([100, 80, 79])(
+    'keeps card-wide minimum guidance with %d selected-tier cap room',
+    (room) => {
+      const { dashboard, fixture } = demoDashboard();
+      const ember = dashboard.cards.find((item) => item.card.id === 'demo-card-ember');
+      expect(ember).toBeDefined();
+
+      const uses = rankCardUses([{
+        ...ember!,
+        status: 'near_cap',
+        maximum: {
+          ...ember!.maximum,
+          target: 500,
+          remaining: room,
+          reached: false,
+        },
+      }], fixture.settings);
+
+      expect(uses).toHaveLength(1);
+      expect(uses[0]?.rankGroup).toBe('building');
+    },
+  );
+
+  it('recommends the strongest prospective tier when every tier minimum is unmet', () => {
     const { dashboard, fixture } = demoDashboard();
     const ember = dashboard.cards.find((item) => item.card.id === 'demo-card-ember');
     expect(ember).toBeDefined();
 
     const uses = rankCardUses([{
       ...ember!,
-      status: 'near_cap',
-      maximum: {
-        ...ember!.maximum,
-        target: 500,
-        remaining: room,
-        reached: false,
+      minimum: {
+        target: null,
+        remaining: null,
+        progress: null,
+        met: null,
       },
+      rewardCategories: ember!.rewardCategories.map((category) => ({
+        ...category,
+        minimum: {
+          target: 500,
+          remaining: 500 - category.spend.total,
+          progress: category.spend.total / 500,
+          met: false,
+        },
+      })),
     }], fixture.settings);
 
-    expect(uses.length > 0).toBe(expected);
-    if (expected) {
-      expect(uses[0]?.rankGroup).toBe('building');
-    }
+    expect(uses).toHaveLength(1);
+    expect(uses[0]).toMatchObject({
+      use: { label: 'Groceries' },
+      rate: { prospective: true },
+      rankGroup: 'building',
+      operational: {
+        kind: 'minimum',
+        remaining: 375,
+        category: 'Groceries',
+      },
+    });
   });
 });

--- a/apps/mobile/src/features/cards/reward-categories.test.ts
+++ b/apps/mobile/src/features/cards/reward-categories.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRewardsDashboard } from '@ynab-counter/app-core/rewards-engine';
+import { createDemoStorageFixture } from '@/lib/demo-data';
+
+import { rankCardUses } from './reward-categories';
+
+function demoDashboard() {
+  const now = new Date('2026-08-02T12:00:00');
+  const fixture = createDemoStorageFixture(now);
+  const transactions = fixture.cachedData.dashboardTransactions?.[0]?.transactions ?? [];
+  return {
+    fixture,
+    dashboard: buildRewardsDashboard(fixture.cards, transactions, fixture.settings, now),
+  };
+}
+
+describe('rankCardUses', () => {
+  it('ranks factual earning options without returning capped cards', () => {
+    const { dashboard, fixture } = demoDashboard();
+
+    const uses = rankCardUses(dashboard.cards, fixture.settings);
+
+    expect(uses.map((item) => item.card.card.id)).toEqual([
+      'demo-card-orbit',
+      'demo-card-ember',
+      'demo-card-tide',
+    ]);
+    expect(uses.map((item) => [item.use.label, item.rankGroup])).toEqual([
+      ['Everyday spend', 'current'],
+      ['Groceries', 'building'],
+      ['Everyday spend', 'cap_limited'],
+    ]);
+    expect(uses.some((item) => item.card.card.id === 'demo-card-summit')).toBe(false);
+  });
+
+  it('does not invent everyday spend when enabled tiers are unavailable', () => {
+    const { dashboard, fixture } = demoDashboard();
+    const ember = dashboard.cards.find((item) => item.card.id === 'demo-card-ember');
+    expect(ember).toBeDefined();
+
+    const uses = rankCardUses([{
+      ...ember!,
+      rewardCategories: ember!.rewardCategories.map((category) => ({
+        ...category,
+        excluded: true,
+      })),
+    }], fixture.settings);
+
+    expect(uses).toEqual([]);
+  });
+
+  it('omits a block card when its remaining room cannot fit another block', () => {
+    const { dashboard, fixture } = demoDashboard();
+    const orbit = dashboard.cards.find((item) => item.card.id === 'demo-card-orbit');
+    expect(orbit).toBeDefined();
+
+    const uses = rankCardUses([{
+      ...orbit!,
+      status: 'near_cap',
+      maximum: {
+        ...orbit!.maximum,
+        target: 1_000,
+        remaining: 2,
+        reached: false,
+      },
+    }], fixture.settings);
+
+    expect(uses).toEqual([]);
+  });
+
+  it.each([
+    { room: 100, expected: true },
+    { room: 80, expected: true },
+    { room: 79, expected: false },
+  ])('includes a near-cap minimum only when it is reachable with $room room', ({
+    room,
+    expected,
+  }) => {
+    const { dashboard, fixture } = demoDashboard();
+    const ember = dashboard.cards.find((item) => item.card.id === 'demo-card-ember');
+    expect(ember).toBeDefined();
+
+    const uses = rankCardUses([{
+      ...ember!,
+      status: 'near_cap',
+      maximum: {
+        ...ember!.maximum,
+        target: 500,
+        remaining: room,
+        reached: false,
+      },
+    }], fixture.settings);
+
+    expect(uses.length > 0).toBe(expected);
+    if (expected) {
+      expect(uses[0]?.rankGroup).toBe('building');
+    }
+  });
+});

--- a/apps/mobile/src/features/cards/reward-categories.ts
+++ b/apps/mobile/src/features/cards/reward-categories.ts
@@ -2,6 +2,33 @@ import type {
   CardDashboardProjection,
   RewardCategoryProjection,
 } from '@ynab-counter/app-core/rewards-engine';
+import type { AppSettings, CreditCard } from '@ynab-counter/app-core/storage';
+
+export type CardUseRankGroup = 'current' | 'building' | 'cap_limited';
+
+export interface RankedCardUse {
+  key: string;
+  card: CardDashboardProjection;
+  cardOrder: number;
+  use: {
+    label: string;
+    categoryId: string | null;
+    flagColor: RewardCategoryProjection['flagColor'] | null;
+  };
+  rate: {
+    type: CreditCard['type'];
+    value: number;
+    normalized: number;
+    blockSize: number | null;
+    prospective: boolean;
+  };
+  effectiveEarningRoom: number | null;
+  operational:
+    | { kind: 'minimum'; remaining: number; resetsOn: string }
+    | { kind: 'cap'; remaining: number }
+    | null;
+  rankGroup: CardUseRankGroup;
+}
 
 export interface PortfolioRewardCategory {
   key: string;
@@ -13,12 +40,191 @@ export interface PortfolioRewardCategory {
 export function collectRewardCategories(
   cards: CardDashboardProjection[],
 ): PortfolioRewardCategory[] {
-  return cards.flatMap((card, cardOrder) => card.rewardCategories.map((category) => ({
-    key: `${card.card.id}:${category.id}`,
-    card,
-    category,
-    cardOrder,
-  })));
+  return cards.flatMap((card, cardOrder) => card.status === 'capped'
+    ? []
+    : card.rewardCategories.map((category) => ({
+        key: `${card.card.id}:${category.id}`,
+        card,
+        category,
+        cardOrder,
+      })));
+}
+
+function positiveFinite(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+function normalizedRate(
+  type: CreditCard['type'],
+  rate: number,
+  settings: AppSettings,
+): number {
+  if (type === 'cashback') {
+    return rate / 100;
+  }
+
+  const configuredValuation = settings.milesValuation;
+  const milesValuation = typeof configuredValuation === 'number' &&
+    Number.isFinite(configuredValuation)
+    ? configuredValuation
+    : 0.01;
+  return rate * milesValuation;
+}
+
+function remainingRoom(
+  maximum: CardDashboardProjection['maximum'] | RewardCategoryProjection['maximum'],
+): number | null {
+  if (maximum.target === null) {
+    return null;
+  }
+  if (maximum.reached || maximum.remaining === null || maximum.remaining <= 0) {
+    return 0;
+  }
+  return maximum.remaining;
+}
+
+function selectStrongestTier(
+  projection: CardDashboardProjection,
+  settings: AppSettings,
+): RewardCategoryProjection | undefined {
+  return projection.rewardCategories.reduce<RewardCategoryProjection | undefined>(
+    (strongest, category) => {
+      const rate = positiveFinite(category.rate);
+      const tierUnavailable = category.excluded ||
+        category.maximum.reached ||
+        remainingRoom(category.maximum) === 0 ||
+        (category.minimum.target !== null && category.minimum.met === false);
+      if (rate === null || tierUnavailable) {
+        return strongest;
+      }
+      if (!strongest) {
+        return category;
+      }
+
+      const categoryRate = normalizedRate(projection.card.type, rate, settings);
+      const strongestRate = normalizedRate(projection.card.type, strongest.rate, settings);
+      return categoryRate > strongestRate ? category : strongest;
+    },
+    undefined,
+  );
+}
+
+function rankGroupPriority(group: CardUseRankGroup): number {
+  switch (group) {
+    case 'current': return 0;
+    case 'building': return 1;
+    case 'cap_limited': return 2;
+  }
+}
+
+/**
+ * Rank each usable card by its strongest currently available earning use.
+ * Availability and ordering live here so Overview only formats and navigates.
+ */
+export function rankCardUses(
+  cards: CardDashboardProjection[],
+  settings: AppSettings,
+): RankedCardUse[] {
+  const uses = cards.flatMap<RankedCardUse>((projection, cardOrder) => {
+    if (projection.status === 'capped' || projection.status === 'unconfigured') {
+      return [];
+    }
+
+    const selectedTier = projection.card.subcategoriesEnabled
+      ? selectStrongestTier(projection, settings)
+      : undefined;
+    const nativeRate = projection.card.subcategoriesEnabled
+      ? positiveFinite(selectedTier?.rate)
+      : positiveFinite(projection.card.earningRate);
+    if (nativeRate === null || (projection.card.subcategoriesEnabled && !selectedTier)) {
+      return [];
+    }
+
+    const cardRoom = remainingRoom(projection.maximum);
+    const tierRoom = selectedTier ? remainingRoom(selectedTier.maximum) : null;
+    if (cardRoom === 0 || tierRoom === 0) {
+      return [];
+    }
+    const constrainedRooms = [cardRoom, tierRoom].filter(
+      (room): room is number => room !== null && room > 0,
+    );
+    const effectiveEarningRoom = constrainedRooms.length > 0
+      ? Math.min(...constrainedRooms)
+      : null;
+    const blockSize = positiveFinite(selectedTier
+      ? selectedTier.blockInfo?.size
+      : projection.card.earningBlockSize);
+    if (
+      blockSize !== null &&
+      effectiveEarningRoom !== null &&
+      blockSize > effectiveEarningRoom
+    ) {
+      return [];
+    }
+
+    const cardMinimumUnmet = projection.minimum.target !== null &&
+      projection.minimum.met === false;
+    const capLimited = projection.status === 'near_cap' ||
+      (selectedTier?.maximum.progress ?? 0) >= 0.8;
+    if (
+      cardMinimumUnmet &&
+      effectiveEarningRoom !== null &&
+      (projection.minimum.remaining ?? 0) > effectiveEarningRoom
+    ) {
+      return [];
+    }
+    const rankGroup: CardUseRankGroup = cardMinimumUnmet
+      ? 'building'
+      : capLimited
+        ? 'cap_limited'
+        : 'current';
+
+    return [{
+      key: projection.card.id,
+      card: projection,
+      cardOrder,
+      use: {
+        label: selectedTier?.name ?? 'Everyday spend',
+        categoryId: selectedTier?.id ?? null,
+        flagColor: selectedTier?.flagColor ?? null,
+      },
+      rate: {
+        type: projection.card.type,
+        value: nativeRate,
+        normalized: normalizedRate(projection.card.type, nativeRate, settings),
+        blockSize,
+        prospective: cardMinimumUnmet,
+      },
+      effectiveEarningRoom,
+      operational: cardMinimumUnmet
+        ? {
+            kind: 'minimum',
+            remaining: projection.minimum.remaining ?? 0,
+            resetsOn: projection.resetsOn,
+          }
+        : effectiveEarningRoom !== null
+          ? { kind: 'cap', remaining: effectiveEarningRoom }
+          : null,
+      rankGroup,
+    }];
+  });
+
+  return uses.sort((left, right) => {
+    const groupDifference = rankGroupPriority(left.rankGroup) -
+      rankGroupPriority(right.rankGroup);
+    if (groupDifference !== 0) {
+      return groupDifference;
+    }
+
+    const rateDifference = right.rate.normalized - left.rate.normalized;
+    if (rateDifference !== 0) {
+      return rateDifference;
+    }
+
+    return left.cardOrder - right.cardOrder;
+  });
 }
 
 function previewUrgency(item: PortfolioRewardCategory): number {
@@ -68,29 +274,6 @@ export function rankRewardCategoryPreview(
       const spendDifference = right.category.spend.total - left.category.spend.total;
       if (spendDifference !== 0) {
         return spendDifference;
-      }
-
-      const cardOrderDifference = left.cardOrder - right.cardOrder;
-      if (cardOrderDifference !== 0) {
-        return cardOrderDifference;
-      }
-
-      return left.category.priority - right.category.priority;
-    })
-    .slice(0, Math.max(0, limit));
-}
-
-/** Rank earned reward tiers by estimated cross-card value, preserving stable configured order for ties. */
-export function rankRewardCategoryEarnings(
-  categories: PortfolioRewardCategory[],
-  limit = 3,
-): PortfolioRewardCategory[] {
-  return categories
-    .filter(({ category }) => !category.excluded && category.reward.amount > 0)
-    .sort((left, right) => {
-      const valueDifference = right.category.reward.dollars - left.category.reward.dollars;
-      if (valueDifference !== 0) {
-        return valueDifference;
       }
 
       const cardOrderDifference = left.cardOrder - right.cardOrder;

--- a/apps/mobile/src/features/cards/reward-categories.ts
+++ b/apps/mobile/src/features/cards/reward-categories.ts
@@ -79,3 +79,26 @@ export function rankRewardCategoryPreview(
     })
     .slice(0, Math.max(0, limit));
 }
+
+/** Rank earned reward tiers by estimated cross-card value, preserving stable configured order for ties. */
+export function rankRewardCategoryEarnings(
+  categories: PortfolioRewardCategory[],
+  limit = 3,
+): PortfolioRewardCategory[] {
+  return categories
+    .filter(({ category }) => !category.excluded && category.reward.amount > 0)
+    .sort((left, right) => {
+      const valueDifference = right.category.reward.dollars - left.category.reward.dollars;
+      if (valueDifference !== 0) {
+        return valueDifference;
+      }
+
+      const cardOrderDifference = left.cardOrder - right.cardOrder;
+      if (cardOrderDifference !== 0) {
+        return cardOrderDifference;
+      }
+
+      return left.category.priority - right.category.priority;
+    })
+    .slice(0, Math.max(0, limit));
+}

--- a/apps/mobile/src/features/cards/reward-categories.ts
+++ b/apps/mobile/src/features/cards/reward-categories.ts
@@ -24,7 +24,7 @@ export interface RankedCardUse {
   };
   effectiveEarningRoom: number | null;
   operational:
-    | { kind: 'minimum'; remaining: number; resetsOn: string }
+    | { kind: 'minimum'; remaining: number; resetsOn: string; category: string | null }
     | { kind: 'cap'; remaining: number }
     | null;
   rankGroup: CardUseRankGroup;
@@ -94,13 +94,20 @@ function selectStrongestTier(
       const rate = positiveFinite(category.rate);
       const tierUnavailable = category.excluded ||
         category.maximum.reached ||
-        remainingRoom(category.maximum) === 0 ||
-        (category.minimum.target !== null && category.minimum.met === false);
+        remainingRoom(category.maximum) === 0;
       if (rate === null || tierUnavailable) {
         return strongest;
       }
       if (!strongest) {
         return category;
+      }
+
+      const categoryMinimumUnmet = category.minimum.target !== null &&
+        category.minimum.met === false;
+      const strongestMinimumUnmet = strongest.minimum.target !== null &&
+        strongest.minimum.met === false;
+      if (categoryMinimumUnmet !== strongestMinimumUnmet) {
+        return categoryMinimumUnmet ? strongest : category;
       }
 
       const categoryRate = normalizedRate(projection.card.type, rate, settings);
@@ -166,16 +173,12 @@ export function rankCardUses(
 
     const cardMinimumUnmet = projection.minimum.target !== null &&
       projection.minimum.met === false;
+    const tierMinimumUnmet = selectedTier?.minimum.target !== null &&
+      selectedTier?.minimum.met === false;
+    const minimumUnmet = cardMinimumUnmet || tierMinimumUnmet;
     const capLimited = projection.status === 'near_cap' ||
       (selectedTier?.maximum.progress ?? 0) >= 0.8;
-    if (
-      cardMinimumUnmet &&
-      effectiveEarningRoom !== null &&
-      (projection.minimum.remaining ?? 0) > effectiveEarningRoom
-    ) {
-      return [];
-    }
-    const rankGroup: CardUseRankGroup = cardMinimumUnmet
+    const rankGroup: CardUseRankGroup = minimumUnmet
       ? 'building'
       : capLimited
         ? 'cap_limited'
@@ -195,14 +198,18 @@ export function rankCardUses(
         value: nativeRate,
         normalized: normalizedRate(projection.card.type, nativeRate, settings),
         blockSize,
-        prospective: cardMinimumUnmet,
+        prospective: minimumUnmet,
       },
       effectiveEarningRoom,
-      operational: cardMinimumUnmet
+      operational: minimumUnmet
         ? {
             kind: 'minimum',
-            remaining: projection.minimum.remaining ?? 0,
+            remaining: Math.max(
+              cardMinimumUnmet ? (projection.minimum.remaining ?? 0) : 0,
+              tierMinimumUnmet ? (selectedTier?.minimum.remaining ?? 0) : 0,
+            ),
             resetsOn: projection.resetsOn,
+            category: tierMinimumUnmet ? (selectedTier?.name ?? null) : null,
           }
         : effectiveEarningRoom !== null
           ? { kind: 'cap', remaining: effectiveEarningRoom }


### PR DESCRIPTION
## Summary

- simplify native iOS navigation, card detail, settings, and status presentation by removing routine badges, duplicated headings, and redundant controls
- redesign Overview around forward-looking card decisions instead of a prominent estimated-value dashboard
- show only cards that can still earn, with their strongest factual earning use, native rate, and relevant minimum/cap constraint
- preserve actionable sync/tier exceptions, YNAB flag colours, Dynamic Type behaviour, and complete portfolio access in Cards/detail

## Product behaviour

- capped cards are omitted from Overview and its category drill-down
- `Keep using` ranks currently earning cards, feasible minimum-building opportunities, then near-cap cards
- tier selection excludes unavailable, excluded, capped, and unmet-tier-minimum options
- block sizes and effective card/tier cap room prevent recommendations that cannot earn
- unconfigured cards remain available through a compact `Set up` section

## Validation

- `pnpm --filter ./apps/mobile test` — 60 tests passed
- `pnpm --filter ./apps/mobile typecheck`
- ESLint on changed mobile implementation and test files
- `git diff --check`
- iOS simulator review at default and Extra Extra Large Dynamic Type
- local Codex closeout review with no actionable findings
