### PR TITLE
feat(mobile): bring the iOS app to web-feature parity

### DIFF
--- a/apps/mobile/app/(tabs)/activity/index.tsx
+++ b/apps/mobile/app/(tabs)/activity/index.tsx
@@ -104,6 +104,10 @@ export default function ActivityScreen() {
     () => model.cacheEntry?.accounts ?? [],
     [model.cacheEntry],
   );
+  const selectedAccountName = useMemo(
+    () => accounts.find((account) => account.id === selectedAccountId)?.name,
+    [accounts, selectedAccountId],
+  );
 
   const openTransaction = useCallback((id: string) => {
     router.push({
@@ -142,10 +146,31 @@ export default function ActivityScreen() {
   }, [openTransaction, state.settings]);
 
   const isSearching = query.trim().length > 0;
+  const isFilteringAccount = Boolean(selectedAccountId);
   const resultCount = model.transactions.length;
   const resultCopy = isSearching
     ? `${resultCount} ${resultCount === 1 ? 'match' : 'matches'}`
     : `${resultCount} ${resultCount === 1 ? 'transaction' : 'transactions'}`;
+  const emptyTitle = isSearching
+    ? 'No matching activity'
+    : isFilteringAccount
+      ? 'No activity for this account'
+      : !model.isHydrated
+        ? 'Loading activity'
+        : model.hasConnection
+          ? 'No saved activity yet'
+          : 'Connect YNAB to see activity';
+  const emptyMessage = isSearching
+    ? `Nothing matches “${query.trim()}”.`
+    : isFilteringAccount
+      ? selectedAccountName
+        ? `No saved transactions for ${selectedAccountName}.`
+        : 'No saved transactions for this account.'
+      : !model.isHydrated
+        ? 'Your saved transactions will appear in a moment.'
+        : model.hasConnection
+          ? 'Pull down to fetch transactions for your tracked cards.'
+          : 'Tracked card transactions and their estimated rewards will appear here.';
 
   return (
     <SectionList<TransactionProjection, ActivitySection>
@@ -214,21 +239,9 @@ export default function ActivityScreen() {
                 accessibilityElementsHidden
               />
             )}
-            title={isSearching
-              ? 'No matching activity'
-              : !model.isHydrated
-                ? 'Loading activity'
-                : model.hasConnection
-                  ? 'No saved activity yet'
-                  : 'Connect YNAB to see activity'}
-            message={isSearching
-              ? `Nothing matches “${query.trim()}”.`
-              : !model.isHydrated
-                ? 'Your saved transactions will appear in a moment.'
-                : model.hasConnection
-                  ? 'Pull down to fetch transactions for your tracked cards.'
-                  : 'Tracked card transactions and their estimated rewards will appear here.'}
-            action={isSearching
+            title={emptyTitle}
+            message={emptyMessage}
+            action={isSearching || isFilteringAccount
               ? undefined
               : model.hasConnection
                 ? {

--- a/apps/mobile/app/(tabs)/activity/index.tsx
+++ b/apps/mobile/app/(tabs)/activity/index.tsx
@@ -327,7 +327,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: nativeMetrics.screenGutter,
   },
   filterChip: {
-    minHeight: 32,
+    minHeight: nativeMetrics.minimumTouchTarget,
     justifyContent: 'center',
     paddingHorizontal: spacing.md,
     borderRadius: radii.pill,

--- a/apps/mobile/app/(tabs)/activity/index.tsx
+++ b/apps/mobile/app/(tabs)/activity/index.tsx
@@ -1,6 +1,8 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
+  Pressable,
   RefreshControl,
+  ScrollView,
   SectionList,
   StyleSheet,
   Text,
@@ -23,14 +25,85 @@ import {
   type ActivitySection,
 } from '@/features/activity';
 import { semanticColors } from '@/theme';
-import { nativeMetrics, radii, spacing } from '@/theme/tokens';
+import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
 import type { TransactionProjection } from '@ynab-counter/app-core/rewards-engine';
+
+function AccountFilterChips({
+  accounts,
+  selectedAccountId,
+  onSelect,
+}: {
+  accounts: { id: string; name: string }[];
+  selectedAccountId?: string;
+  onSelect: (accountId: string | undefined) => void;
+}) {
+  const chips = useMemo(() => {
+    const seen = new Set<string>();
+    const unique = accounts.filter((account) => {
+      if (seen.has(account.id)) {
+        return false;
+      }
+      seen.add(account.id);
+      return true;
+    });
+    return [{ id: undefined, name: 'All accounts' }, ...unique] as {
+      id?: string;
+      name: string;
+    }[];
+  }, [accounts]);
+
+  if (chips.length <= 1) {
+    return null;
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.filterChips}
+      style={styles.filterScroll}
+      accessibilityRole="none"
+    >
+      {chips.map((chip) => {
+        const selected = chip.id === selectedAccountId;
+        return (
+          <Pressable
+            key={chip.id ?? 'all'}
+            onPress={() => onSelect(chip.id)}
+            accessibilityRole="button"
+            accessibilityLabel={chip.name}
+            accessibilityState={{ selected }}
+            style={({ pressed }) => [
+              styles.filterChip,
+              selected && styles.filterChipSelected,
+              pressed && styles.filterChipPressed,
+            ]}
+          >
+            <Footnote
+              color={selected ? 'primary' : 'secondary'}
+              style={[styles.filterChipLabel, selected && styles.filterChipLabelSelected]}
+              accessible={false}
+            >
+              {chip.name}
+            </Footnote>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
 
 export default function ActivityScreen() {
   const router = useRouter();
   const { state } = useStorage();
   const [query, setQuery] = useState('');
-  const model = useActivityModel(query);
+  const [selectedAccountId, setSelectedAccountId] = useState<string | undefined>(undefined);
+  const model = useActivityModel(query, selectedAccountId);
+  const accounts = useMemo(
+    () => model.cacheEntry?.accounts ?? [],
+    [model.cacheEntry],
+  );
 
   const openTransaction = useCallback((id: string) => {
     router.push({
@@ -112,6 +185,11 @@ export default function ActivityScreen() {
                 style={styles.searchInput}
               />
             </View>
+            <AccountFilterChips
+              accounts={accounts}
+              selectedAccountId={selectedAccountId}
+              onSelect={setSelectedAccountId}
+            />
             <View style={styles.orientation}>
               <Footnote color="secondary">{resultCopy}</Footnote>
               <SyncBadge
@@ -225,6 +303,34 @@ const styles = StyleSheet.create({
   searchFallback: {
     color: semanticColors.secondaryLabel,
     fontSize: 18,
+  },
+  filterScroll: {
+    flexGrow: 0,
+    marginHorizontal: -nativeMetrics.screenGutter,
+  },
+  filterChips: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: nativeMetrics.screenGutter,
+  },
+  filterChip: {
+    minHeight: 32,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.secondarySystemGroupedBackground,
+  },
+  filterChipSelected: {
+    backgroundColor: semanticColors.actionTint,
+  },
+  filterChipPressed: {
+    opacity: interaction.pressedOpacity,
+  },
+  filterChipLabel: {
+    fontWeight: '500',
+  },
+  filterChipLabelSelected: {
+    color: semanticColors.action,
   },
   orientation: {
     minHeight: nativeMetrics.minimumTouchTarget,

--- a/apps/mobile/app/(tabs)/cards/index.tsx
+++ b/apps/mobile/app/(tabs)/cards/index.tsx
@@ -25,10 +25,12 @@ import {
   useRewardsDashboard,
 } from '@/features/cards/dashboard';
 import {
+  countActiveFlagRules,
   createCardFormatting,
   formatReward,
   formatThresholdSummary,
   isCardConfigured,
+  isPromotionalPeriodActive,
   primaryProgress,
   statusPresentation,
 } from '@/features/cards/presentation';
@@ -68,10 +70,8 @@ function ManagementRow({
       status={configured
         ? statusPresentation(projection.status)
         : { label: 'Needs setup', tone: 'attention' }}
-      promo={Boolean(projection.card.promotionalPeriod)}
-      ruleCount={projection.card.subcategoriesEnabled
-        ? (projection.card.subcategories?.length ?? 0)
-        : 0}
+      promo={isPromotionalPeriodActive(projection.card)}
+      ruleCount={countActiveFlagRules(projection.card)}
       onPress={onPress}
       showDivider={showDivider}
     />

--- a/apps/mobile/app/(tabs)/cards/index.tsx
+++ b/apps/mobile/app/(tabs)/cards/index.tsx
@@ -68,6 +68,10 @@ function ManagementRow({
       status={configured
         ? statusPresentation(projection.status)
         : { label: 'Needs setup', tone: 'attention' }}
+      promo={Boolean(projection.card.promotionalPeriod)}
+      ruleCount={projection.card.subcategoriesEnabled
+        ? (projection.card.subcategories?.length ?? 0)
+        : 0}
       onPress={onPress}
       showDivider={showDivider}
     />

--- a/apps/mobile/app/(tabs)/overview/_layout.tsx
+++ b/apps/mobile/app/(tabs)/overview/_layout.tsx
@@ -27,6 +27,13 @@ export default function OverviewLayout() {
           headerLargeTitle: !usesIOS26LargeTitleFallback,
         }}
       />
+      <Stack.Screen
+        name="period"
+        options={{
+          title: 'Dashboard period',
+          presentation: 'formSheet',
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/overview/categories.tsx
+++ b/apps/mobile/app/(tabs)/overview/categories.tsx
@@ -23,13 +23,16 @@ import {
   createCardFormatting,
   formatPeriod,
 } from '@/features/cards/presentation';
+import { useDashboardPeriod } from '@/features/overview';
 import { semanticColors } from '@/theme';
 import { nativeMetrics, radii, spacing } from '@/theme/tokens';
 
 export default function RewardCategoriesScreen() {
   const router = useRouter();
   const { state } = useStorage();
-  const model = useRewardsDashboard();
+  const period = useDashboardPeriod();
+  const referenceDate = period.isToday ? undefined : period.referenceDate;
+  const model = useRewardsDashboard(referenceDate);
   const formatting = useMemo(
     () => createCardFormatting(state.settings),
     [state.settings],

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -117,6 +117,66 @@ function cardUseOperationalLabel(
   return undefined;
 }
 
+function CardUseRow({
+  item,
+  formatting,
+  onPress,
+  showDivider,
+}: {
+  item: RankedCardUse;
+  formatting: CardFormatting;
+  onPress: () => void;
+  showDivider: boolean;
+}) {
+  const rateLabel = cardUseRateLabel(item, formatting);
+  const operationalLabel = cardUseOperationalLabel(item, formatting);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={[
+        item.card.card.name,
+        item.use.label,
+        rateLabel,
+        operationalLabel,
+      ].filter(Boolean).join(', ')}
+      accessibilityHint={item.use.categoryId
+        ? `Opens the ${item.use.label} earning tier on ${item.card.card.name}`
+        : `Opens details for ${item.card.card.name}`}
+      style={({ pressed }) => [
+        styles.cardUseRow,
+        showDivider && styles.rowDivider,
+        pressed && styles.pressed,
+      ]}
+    >
+      <View
+        style={styles.rowCopy}
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+      >
+        <Headline>{compactCardName(item.card.card.name)}</Headline>
+        <View style={styles.useLabelRow}>
+          {item.use.flagColor ? (
+            <SymbolView
+              name="flag.fill"
+              size={14}
+              tintColor={flagColor(item.use.flagColor)}
+              style={styles.flagIcon}
+            />
+          ) : null}
+          <Body style={styles.flexibleText}>{item.use.label} · {rateLabel}</Body>
+        </View>
+        {operationalLabel ? (
+          <Footnote color="secondary" style={styles.tabular}>
+            {operationalLabel}
+          </Footnote>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
 function SetupCardRow({
   projection,
   onPress,
@@ -563,6 +623,23 @@ export default function OverviewScreen() {
             />
           ) : null}
 
+          {cardUses.length > 0 ? (
+            <View style={styles.section}>
+              <SectionTitle title="Keep using" />
+              <View style={styles.rows}>
+                {cardUses.map((item, index) => (
+                  <CardUseRow
+                    key={item.key}
+                    item={item}
+                    formatting={formatting}
+                    onPress={() => openCardUse(item)}
+                    showDivider={index < cardUses.length - 1}
+                  />
+                ))}
+              </View>
+            </View>
+          ) : null}
+
           <CardGroupSection
             title="Cashback Cards"
             icon="percent"
@@ -705,6 +782,11 @@ const styles = StyleSheet.create({
     backgroundColor: semanticColors.secondarySystemGroupedBackground,
     overflow: 'hidden',
   },
+  cardUseRow: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+  },
   setupRow: {
     minHeight: nativeMetrics.minimumTouchTarget,
     justifyContent: 'center',
@@ -723,6 +805,19 @@ const styles = StyleSheet.create({
     flex: 1,
     minWidth: 0,
     gap: spacing.xs,
+  },
+  useLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  flexibleText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  flagIcon: {
+    flexShrink: 0,
+    marginTop: 3,
   },
   categoryFlagIcon: {
     flexShrink: 0,

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -10,11 +10,7 @@ import { useRouter } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
 
 import { useStorage } from '@/contexts/StorageContext';
-import {
-  EmptyState,
-  LargeNavigationTitle,
-  SectionTitle,
-} from '@/components/native';
+import { EmptyState, LargeNavigationTitle, SectionTitle } from '@/components/native';
 import { Body, Footnote, Headline } from '@/components/ios';
 import {
   createCardFormatting,
@@ -22,7 +18,10 @@ import {
   formatResetDate,
   type CardFormatting,
 } from '@/features/cards/presentation';
-import { useRewardsDashboard } from '@/features/cards/dashboard';
+import {
+  orderCardProjections,
+  useRewardsDashboard,
+} from '@/features/cards/dashboard';
 import {
   collectRewardCategories,
   rankCardUses,
@@ -30,9 +29,29 @@ import {
   type PortfolioRewardCategory,
   type RankedCardUse,
 } from '@/features/cards/reward-categories';
+import {
+  CardGroupHeader,
+  CardTile,
+  StatusSummary,
+  useDashboardPeriod,
+  type HiddenCardEntry,
+} from '@/features/overview';
 import { semanticColors } from '@/theme';
 import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
 import type { CardDashboardProjection } from '@ynab-counter/app-core/rewards-engine';
+
+function isExpansionMap(
+  value: unknown,
+): value is Record<string, boolean> {
+  return Boolean(
+    value && typeof value === 'object' && !Array.isArray(value),
+  );
+}
+
+function isHiddenAt(cardId: string, hiddenUntil: string, referenceDate: Date): boolean {
+  const expiry = new Date(hiddenUntil).getTime();
+  return Boolean(cardId && Number.isFinite(expiry) && expiry > referenceDate.getTime());
+}
 
 function compactCardName(name: string): string {
   const segments = name
@@ -96,66 +115,6 @@ function cardUseOperationalLabel(
     return `${thresholdCurrency(item.operational.remaining, formatting)} cap room`;
   }
   return undefined;
-}
-
-function CardUseRow({
-  item,
-  formatting,
-  onPress,
-  showDivider,
-}: {
-  item: RankedCardUse;
-  formatting: CardFormatting;
-  onPress: () => void;
-  showDivider: boolean;
-}) {
-  const rateLabel = cardUseRateLabel(item, formatting);
-  const operationalLabel = cardUseOperationalLabel(item, formatting);
-
-  return (
-    <Pressable
-      onPress={onPress}
-      accessibilityRole="button"
-      accessibilityLabel={[
-        item.card.card.name,
-        item.use.label,
-        rateLabel,
-        operationalLabel,
-      ].filter(Boolean).join(', ')}
-      accessibilityHint={item.use.categoryId
-        ? `Opens the ${item.use.label} earning tier on ${item.card.card.name}`
-        : `Opens details for ${item.card.card.name}`}
-      style={({ pressed }) => [
-        styles.cardUseRow,
-        showDivider && styles.rowDivider,
-        pressed && styles.pressed,
-      ]}
-    >
-      <View
-        style={styles.rowCopy}
-        accessibilityElementsHidden
-        importantForAccessibility="no-hide-descendants"
-      >
-        <Headline>{compactCardName(item.card.card.name)}</Headline>
-        <View style={styles.useLabelRow}>
-          {item.use.flagColor ? (
-            <SymbolView
-              name="flag.fill"
-              size={14}
-              tintColor={flagColor(item.use.flagColor)}
-              style={styles.flagIcon}
-            />
-          ) : null}
-          <Body style={styles.flexibleText}>{item.use.label} · {rateLabel}</Body>
-        </View>
-        {operationalLabel ? (
-          <Footnote color="secondary" style={styles.tabular}>
-            {operationalLabel}
-          </Footnote>
-        ) : null}
-      </View>
-    </Pressable>
-  );
 }
 
 function SetupCardRow({
@@ -289,12 +248,100 @@ function CategorySpendRow({
   );
 }
 
+function CardGroupSection({
+  title,
+  icon,
+  iconColor,
+  collapsed,
+  count,
+  onToggle,
+  children,
+}: {
+  title: string;
+  icon: 'percent' | 'chart.line.uptrend.xyaxis';
+  iconColor: React.ComponentProps<typeof SymbolView>['tintColor'];
+  collapsed: boolean;
+  count: number;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  if (count === 0) {
+    return null;
+  }
+  return (
+    <View style={styles.section}>
+      <CardGroupHeader
+        title={title}
+        count={count}
+        icon={icon}
+        iconColor={iconColor}
+        collapsed={collapsed}
+        onToggle={onToggle}
+      />
+      {!collapsed ? <View style={styles.tileStack}>{children}</View> : null}
+    </View>
+  );
+}
+
 export default function OverviewScreen() {
   const router = useRouter();
-  const { state } = useStorage();
-  const model = useRewardsDashboard();
+  const { state, actions } = useStorage();
+  const period = useDashboardPeriod();
+  const referenceDate = period.isToday ? undefined : period.referenceDate;
+  const model = useRewardsDashboard(referenceDate);
   const formatting = useMemo(() => createCardFormatting(state.settings), [state.settings]);
 
+  const orderedCards = useMemo(
+    () => orderCardProjections(
+      model.dashboard.cards,
+      state.settings.cardOrdering?.all,
+      state.settings.cardOrdering?.cashback,
+      state.settings.cardOrdering?.miles,
+    ),
+    [model.dashboard.cards, state.settings.cardOrdering],
+  );
+
+  const activeHiddenEntries = useMemo(() => {
+    if (!period.isToday) {
+      return [];
+    }
+    return state.hiddenCards.filter((entry) =>
+      isHiddenAt(entry.cardId, entry.hiddenUntil, period.referenceDate),
+    );
+  }, [period.isToday, period.referenceDate, state.hiddenCards]);
+
+  const activeHiddenIds = useMemo(
+    () => new Set(activeHiddenEntries.map((entry) => entry.cardId)),
+    [activeHiddenEntries],
+  );
+
+  const dashboardCards = useMemo(
+    () => orderedCards.filter(
+      ({ card }) => card.featured !== false && !activeHiddenIds.has(card.id),
+    ),
+    [activeHiddenIds, orderedCards],
+  );
+
+  const configuredCards = useMemo(
+    () => dashboardCards.filter((projection) => projection.status !== 'unconfigured'),
+    [dashboardCards],
+  );
+  const setupCards = useMemo(
+    () => dashboardCards.filter((projection) => projection.status === 'unconfigured'),
+    [dashboardCards],
+  );
+  const cashbackCards = useMemo(
+    () => configuredCards.filter(({ card }) => card.type === 'cashback'),
+    [configuredCards],
+  );
+  const milesCards = useMemo(
+    () => configuredCards.filter(({ card }) => card.type === 'miles'),
+    [configuredCards],
+  );
+  const earnedDollars = useMemo(
+    () => configuredCards.reduce((sum, projection) => sum + projection.reward.dollars, 0),
+    [configuredCards],
+  );
   const nonCappedCards = useMemo(
     () => model.visibleCards.filter((projection) => projection.status !== 'capped'),
     [model.visibleCards],
@@ -302,10 +349,6 @@ export default function OverviewScreen() {
   const cardUses = useMemo(
     () => rankCardUses(nonCappedCards, state.settings),
     [nonCappedCards, state.settings],
-  );
-  const setupCards = useMemo(
-    () => nonCappedCards.filter((projection) => projection.status === 'unconfigured'),
-    [nonCappedCards],
   );
   const rewardCategories = useMemo(
     () => collectRewardCategories(nonCappedCards),
@@ -315,11 +358,27 @@ export default function OverviewScreen() {
     () => rankRewardCategoryPreview(rewardCategories),
     [rewardCategories],
   );
+
+  const groupCollapsed = state.settings.collapsedCardGroups ?? {};
+  const subcategoryExpansion = state.settings.summaryViewSubcategoriesExpanded;
+
+  const hiddenChips: HiddenCardEntry[] = useMemo(
+    () => activeHiddenEntries.map((entry) => {
+      const card = state.cards.find((candidate) => candidate.id === entry.cardId);
+      return {
+        cardId: entry.cardId,
+        name: card ? compactCardName(card.name) : 'Card',
+        hiddenUntil: entry.hiddenUntil,
+      };
+    }),
+    [activeHiddenEntries, state.cards],
+  );
+
   const syncActionLabel = model.canSync
     ? `${model.syncLabel} — Retry`
     : `${model.syncLabel} — Review settings`;
   const connected = Boolean(state.pat && state.selectedBudget.id);
-  const hasUsableOrSetupCards = cardUses.length > 0 || setupCards.length > 0;
+  const hasDashboardContent = dashboardCards.length > 0;
 
   const openCard = (id: string) => {
     router.push({ pathname: '/card/[id]', params: { id } });
@@ -337,6 +396,78 @@ export default function OverviewScreen() {
   const openRewardCategory = (id: string, categoryId: string) => {
     router.push({ pathname: '/card/[id]', params: { id, categoryId } });
   };
+
+  const toggleGroup = (type: 'cashback' | 'miles') => {
+    void actions.setSettings({
+      collapsedCardGroups: {
+        ...groupCollapsed,
+        [type]: !groupCollapsed[type],
+      },
+    });
+  };
+
+  const toggleSubcategories = (cardId: string) => {
+    const currentValue = isExpansionMap(subcategoryExpansion)
+      ? subcategoryExpansion[cardId] ?? false
+      : Boolean(subcategoryExpansion);
+    const nextValue = !currentValue;
+    const nextSetting: Record<string, boolean> = isExpansionMap(subcategoryExpansion)
+      ? { ...subcategoryExpansion, [cardId]: nextValue }
+      : { [cardId]: nextValue };
+    void actions.setSettings({ summaryViewSubcategoriesExpanded: nextSetting });
+  };
+
+  const isSubcategoryExpanded = (cardId: string): boolean =>
+    isExpansionMap(subcategoryExpansion)
+      ? subcategoryExpansion[cardId] ?? false
+      : Boolean(subcategoryExpansion);
+
+  const hideCard = async (cardId: string, hiddenUntil: string) => {
+    const next = [
+      ...state.hiddenCards.filter((entry) => entry.cardId !== cardId),
+      { cardId, hiddenUntil, reason: 'maximum_spend_reached' as const },
+    ];
+    await actions.setHiddenCards(next);
+  };
+
+  const unhideCard = async (cardId: string) => {
+    await actions.setHiddenCards(
+      state.hiddenCards.filter((entry) => entry.cardId !== cardId),
+    );
+  };
+
+  const unhideAll = async () => {
+    await actions.setHiddenCards(
+      state.hiddenCards.filter((entry) =>
+        !isHiddenAt(entry.cardId, entry.hiddenUntil, period.referenceDate)),
+    );
+  };
+
+  const periodTrigger = (
+    <Pressable
+      onPress={() => router.push('/(tabs)/overview/period')}
+      accessibilityRole="button"
+      accessibilityLabel={`Dashboard period, ${period.isToday ? 'today' : period.asOfLabel}`}
+      accessibilityHint="Changes the dashboard period"
+      style={({ pressed }) => [styles.periodPill, pressed && styles.pressed]}
+    >
+      <SymbolView
+        name={period.isToday ? 'calendar' : 'clock.arrow.circlepath'}
+        size={13}
+        tintColor={semanticColors.action}
+        accessibilityElementsHidden
+      />
+      <Footnote color={period.isToday ? 'action' : 'primary'} style={styles.periodLabel} accessible={false}>
+        {period.triggerLabel}
+      </Footnote>
+      <SymbolView
+        name="chevron.down"
+        size={9}
+        tintColor={semanticColors.tertiaryLabel}
+        accessibilityElementsHidden
+      />
+    </Pressable>
+  );
 
   return (
     <ScrollView
@@ -358,23 +489,26 @@ export default function OverviewScreen() {
         <LargeNavigationTitle style={styles.navigationTitle}>
           Overview
         </LargeNavigationTitle>
-        {connected && state.cards.length > 0 &&
-        (model.syncState === 'offline' || model.syncState === 'attention') ? (
-          <Pressable
-            onPress={model.canSync ? model.refresh : () => router.push('/settings')}
-            accessibilityRole="button"
-            accessibilityLabel={syncActionLabel}
-            accessibilityHint={model.canSync
-              ? 'Retries syncing rewards from YNAB'
-              : 'Opens YNAB connection settings'}
-            style={({ pressed }) => [
-              styles.syncAction,
-              pressed && styles.pressed,
-            ]}
-          >
-            <Footnote color="action">{syncActionLabel}</Footnote>
-          </Pressable>
-        ) : null}
+        <View style={styles.topRow}>
+          {periodTrigger}
+          {connected && state.cards.length > 0 &&
+          (model.syncState === 'offline' || model.syncState === 'attention') ? (
+            <Pressable
+              onPress={model.canSync ? model.refresh : () => router.push('/settings')}
+              accessibilityRole="button"
+              accessibilityLabel={syncActionLabel}
+              accessibilityHint={model.canSync
+                ? 'Retries syncing rewards from YNAB'
+                : 'Opens YNAB connection settings'}
+              style={({ pressed }) => [
+                styles.syncAction,
+                pressed && styles.pressed,
+              ]}
+            >
+              <Footnote color="action">{syncActionLabel}</Footnote>
+            </Pressable>
+          ) : null}
+        </View>
       </View>
 
       {!connected ? (
@@ -395,33 +529,83 @@ export default function OverviewScreen() {
             accessibilityHint: 'Opens tracked account settings',
           }}
         />
-      ) : !hasUsableOrSetupCards ? (
-        <EmptyState
-          title="No cards to use right now"
-          action={{
-            label: 'View cards',
-            onPress: () => router.push('/(tabs)/cards'),
-            accessibilityHint: 'Opens all cards',
-          }}
-        />
+      ) : !hasDashboardContent && cardUses.length === 0 ? (
+        activeHiddenEntries.length > 0 ? (
+          <EmptyState
+            title="All cards hidden"
+            message="Cards stay hidden until their next cycle resets."
+            action={{
+              label: 'Show hidden cards now',
+              onPress: () => void unhideAll(),
+              accessibilityHint: 'Restores every temporarily hidden card to Overview',
+            }}
+          />
+        ) : (
+          <EmptyState
+            title="No cards to use right now"
+            action={{
+              label: 'View cards',
+              onPress: () => router.push('/(tabs)/cards'),
+              accessibilityHint: 'Opens all cards',
+            }}
+          />
+        )
       ) : (
         <>
-          {cardUses.length > 0 ? (
-            <View style={styles.section}>
-              <SectionTitle title="Keep using" />
-              <View style={styles.rows}>
-                {cardUses.map((item, index) => (
-                  <CardUseRow
-                    key={item.key}
-                    item={item}
-                    formatting={formatting}
-                    onPress={() => openCardUse(item)}
-                    showDivider={index < cardUses.length - 1}
-                  />
-                ))}
-              </View>
-            </View>
+          {configuredCards.length > 0 ? (
+            <StatusSummary
+              projections={configuredCards}
+              earnedDollars={earnedDollars}
+              formatting={formatting}
+              hiddenCards={period.isToday ? hiddenChips : undefined}
+              onUnhideCard={period.isToday ? (cardId) => void unhideCard(cardId) : undefined}
+              onUnhideAll={period.isToday ? () => void unhideAll() : undefined}
+            />
           ) : null}
+
+          <CardGroupSection
+            title="Cashback Cards"
+            icon="percent"
+            iconColor={semanticColors.positive}
+            collapsed={groupCollapsed.cashback ?? false}
+            count={cashbackCards.length}
+            onToggle={() => toggleGroup('cashback')}
+          >
+            {cashbackCards.map((projection) => (
+              <CardTile
+                key={projection.card.id}
+                projection={projection}
+                formatting={formatting}
+                allowHideCard={period.isToday}
+                isSubcategoryExpanded={isSubcategoryExpanded(projection.card.id)}
+                onToggleSubcategories={() => toggleSubcategories(projection.card.id)}
+                onHideCard={(cardId, hiddenUntil) => void hideCard(cardId, hiddenUntil)}
+                onOpen={() => openCard(projection.card.id)}
+              />
+            ))}
+          </CardGroupSection>
+
+          <CardGroupSection
+            title="Miles Cards"
+            icon="chart.line.uptrend.xyaxis"
+            iconColor={semanticColors.systemBlue}
+            collapsed={groupCollapsed.miles ?? false}
+            count={milesCards.length}
+            onToggle={() => toggleGroup('miles')}
+          >
+            {milesCards.map((projection) => (
+              <CardTile
+                key={projection.card.id}
+                projection={projection}
+                formatting={formatting}
+                allowHideCard={period.isToday}
+                isSubcategoryExpanded={isSubcategoryExpanded(projection.card.id)}
+                onToggleSubcategories={() => toggleSubcategories(projection.card.id)}
+                onHideCard={(cardId, hiddenUntil) => void hideCard(cardId, hiddenUntil)}
+                onOpen={() => openCard(projection.card.id)}
+              />
+            ))}
+          </CardGroupSection>
 
           {setupCards.length > 0 ? (
             <View style={styles.section}>
@@ -485,12 +669,34 @@ const styles = StyleSheet.create({
   navigationTitle: {
     marginTop: spacing.sm,
   },
+  topRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  periodPill: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.secondarySystemGroupedBackground,
+  },
+  periodLabel: {
+    fontWeight: '600',
+  },
   syncAction: {
     minHeight: nativeMetrics.minimumTouchTarget,
     alignSelf: 'flex-start',
     justifyContent: 'center',
+    marginLeft: 'auto',
   },
   section: {
+    gap: spacing.md,
+  },
+  tileStack: {
     gap: spacing.md,
   },
   rows: {
@@ -498,11 +704,6 @@ const styles = StyleSheet.create({
     borderRadius: radii.large,
     backgroundColor: semanticColors.secondarySystemGroupedBackground,
     overflow: 'hidden',
-  },
-  cardUseRow: {
-    minHeight: nativeMetrics.minimumTouchTarget,
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.md,
   },
   setupRow: {
     minHeight: nativeMetrics.minimumTouchTarget,
@@ -523,19 +724,6 @@ const styles = StyleSheet.create({
     minWidth: 0,
     gap: spacing.xs,
   },
-  useLabelRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: spacing.sm,
-  },
-  flexibleText: {
-    flex: 1,
-    minWidth: 0,
-  },
-  flagIcon: {
-    flexShrink: 0,
-    marginTop: 3,
-  },
   categoryFlagIcon: {
     flexShrink: 0,
     marginTop: 2,
@@ -548,6 +736,6 @@ const styles = StyleSheet.create({
     borderBottomColor: semanticColors.separator,
   },
   pressed: {
-    opacity: interaction.subtlePressedOpacity,
+    opacity: interaction.pressedOpacity,
   },
 });

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -653,6 +653,7 @@ export default function OverviewScreen() {
                 key={projection.card.id}
                 projection={projection}
                 formatting={formatting}
+                referenceDate={period.referenceDate}
                 allowHideCard={period.isToday}
                 isSubcategoryExpanded={isSubcategoryExpanded(projection.card.id)}
                 onToggleSubcategories={() => toggleSubcategories(projection.card.id)}
@@ -675,6 +676,7 @@ export default function OverviewScreen() {
                 key={projection.card.id}
                 projection={projection}
                 formatting={formatting}
+                referenceDate={period.referenceDate}
                 allowHideCard={period.isToday}
                 isSubcategoryExpanded={isSubcategoryExpanded(projection.card.id)}
                 onToggleSubcategories={() => toggleSubcategories(projection.card.id)}

--- a/apps/mobile/app/(tabs)/overview/period.tsx
+++ b/apps/mobile/app/(tabs)/overview/period.tsx
@@ -1,0 +1,314 @@
+import React, { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { SymbolView } from 'expo-symbols';
+
+import { Body, Button, Caption1, Footnote, Headline, Title3 } from '@/components/ios';
+import {
+  getDashboardPeriodValue,
+  setDashboardPeriodValue,
+  todayDateValue,
+} from '@/features/overview/period-store';
+import {
+  formatDateValue,
+  parseDateValue,
+  shiftDashboardPeriodDays,
+  shiftDashboardPeriodMonths,
+} from '@/lib/dashboard-period';
+import { semanticColors } from '@/theme';
+import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
+import type { TextColor } from '@/components/ios/Typography';
+
+function StepperRow({
+  label,
+  value,
+  onStep,
+  canStepForward,
+}: {
+  label: string;
+  value: string;
+  onStep: (delta: number) => void;
+  canStepForward: boolean;
+}) {
+  return (
+    <View style={styles.stepperRow}>
+      <Caption1 color="secondary" style={styles.stepperLabel}>{label}</Caption1>
+      <View style={styles.stepperControls}>
+        <Pressable
+          onPress={() => onStep(-1)}
+          accessibilityRole="button"
+          accessibilityLabel={`Earlier ${label.toLowerCase()}`}
+          style={({ pressed }) => [styles.stepButton, pressed && styles.pressed]}
+        >
+          <SymbolView
+            name="chevron.left"
+            size={15}
+            tintColor={semanticColors.action}
+            accessibilityElementsHidden
+          />
+        </Pressable>
+        <Headline style={styles.stepValue} accessible={false}>{value}</Headline>
+        <Pressable
+          onPress={() => onStep(1)}
+          disabled={!canStepForward}
+          accessibilityRole="button"
+          accessibilityLabel={`Later ${label.toLowerCase()}`}
+          accessibilityState={{ disabled: !canStepForward }}
+          style={({ pressed }) => [styles.stepButton, !canStepForward && styles.stepButtonDisabled, pressed && styles.pressed]}
+        >
+          <SymbolView
+            name="chevron.right"
+            size={15}
+            tintColor={canStepForward ? semanticColors.action : semanticColors.tertiaryLabel}
+            accessibilityElementsHidden
+          />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export default function DashboardPeriodScreen() {
+  const router = useRouter();
+  const [dateValue, setDateValue] = useState(() => getDashboardPeriodValue() ?? todayDateValue());
+  const todayValue = todayDateValue();
+  const isToday = dateValue === todayValue;
+  const dateLabel = formatDateValue(parseDateValue(dateValue) ?? new Date());
+  const snapshotLabel = isToday
+    ? { text: 'Live snapshot', color: 'positive' as TextColor }
+    : { text: 'Historical snapshot', color: 'attention' as TextColor };
+  const snapshotDetail = isToday
+    ? 'Rewards show today\u2019s current progress.'
+    : `Spend and rewards as they stood on ${dateLabel}.`;
+
+  const commit = () => {
+    setDashboardPeriodValue(dateValue);
+    router.back();
+  };
+
+  const resetToday = () => {
+    setDashboardPeriodValue(undefined);
+    router.back();
+  };
+
+  const stepDays = (delta: number) => {
+    setDateValue(shiftDashboardPeriodDays(dateValue, delta));
+  };
+
+  const stepMonths = (delta: number) => {
+    setDateValue(shiftDashboardPeriodMonths(dateValue, delta));
+  };
+
+  const dayLabel = dateValue === todayValue
+    ? 'Today'
+    : new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short' })
+      .format(parseDateValue(dateValue) ?? new Date());
+  const monthLabel = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' })
+    .format(parseDateValue(dateValue) ?? new Date());
+  const canStepForward = !isToday;
+  const canGoEarlier = parseDateValue(dateValue) !== null;
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Dashboard period' }} />
+      <KeyboardAvoidingView
+        style={styles.screen}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.content}>
+          <View style={styles.snapshot}>
+            <View style={styles.snapshotRow}>
+              <View style={[styles.snapshotDot, { backgroundColor: isToday ? semanticColors.positive : semanticColors.attention }]} />
+              <Body color={snapshotLabel.color} style={styles.snapshotLabel}>{snapshotLabel.text}</Body>
+            </View>
+            <Title3 style={styles.tabular}>{dateLabel}</Title3>
+            <Footnote color="secondary">{monthLabel}</Footnote>
+            <Footnote color="secondary">{snapshotDetail}</Footnote>
+          </View>
+
+          {!isToday ? (
+            <View style={styles.section}>
+              <View style={styles.group}>
+                <Button
+                  variant="filled"
+                  size="medium"
+                  onPress={resetToday}
+                  accessibilityHint="Returns the dashboard to live mode"
+                >
+                  Back to today
+                </Button>
+              </View>
+            </View>
+          ) : null}
+
+          <View style={styles.section}>
+            <Caption1 color="secondary" style={styles.sectionTitle}>Step through time</Caption1>
+            <View style={styles.group}>
+              <StepperRow
+                label="Day"
+                value={dayLabel}
+                onStep={stepDays}
+                canStepForward={canStepForward}
+              />
+              <View style={styles.rowDivider} />
+              <StepperRow
+                label="Month"
+                value={monthLabel}
+                onStep={stepMonths}
+                canStepForward={canStepForward}
+              />
+            </View>
+          </View>
+
+          <View style={styles.section}>
+            <Caption1 color="secondary" style={styles.sectionTitle}>Jump to a date</Caption1>
+            <View style={styles.group}>
+              <View style={styles.jumpRow}>
+                <TextInput
+                  value={dateValue}
+                  onChangeText={setDateValue}
+                  placeholder="YYYY-MM-DD"
+                  placeholderTextColor={semanticColors.tertiaryLabel}
+                  keyboardType="numbers-and-punctuation"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  accessibilityLabel="Date in YYYY-MM-DD format"
+                  style={styles.input}
+                />
+                {!canGoEarlier ? (
+                  <Footnote color="attention" style={styles.inputError}>
+                    Enter a date on or before today
+                  </Footnote>
+                ) : null}
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.footer}>
+          <Button
+            variant="filled"
+            size="large"
+            onPress={commit}
+            disabled={!canGoEarlier}
+            accessibilityHint="Shows the dashboard as it stood on the selected date"
+          >
+            View this date
+          </Button>
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: semanticColors.systemGroupedBackground,
+  },
+  content: {
+    flex: 1,
+    padding: nativeMetrics.screenGutter,
+    gap: spacing.xxl,
+  },
+  snapshot: {
+    gap: spacing.xs,
+    padding: spacing.xl,
+    borderRadius: radii.xlarge,
+    backgroundColor: semanticColors.secondarySystemGroupedBackground,
+  },
+  snapshotRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  snapshotDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  snapshotLabel: {
+    fontWeight: '600',
+  },
+  section: {
+    gap: spacing.sm,
+  },
+  sectionTitle: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    fontWeight: '600',
+  },
+  group: {
+    borderRadius: radii.large,
+    backgroundColor: semanticColors.secondarySystemGroupedBackground,
+    overflow: 'hidden',
+    padding: spacing.lg,
+    gap: spacing.lg,
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+  stepperLabel: {
+    flexShrink: 0,
+  },
+  stepperControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  stepButton: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radii.medium,
+    backgroundColor: semanticColors.tertiarySystemFill,
+  },
+  stepButtonDisabled: {
+    opacity: interaction.disabledOpacity,
+  },
+  stepValue: {
+    minWidth: 110,
+    textAlign: 'center',
+  },
+  rowDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: semanticColors.separator,
+  },
+  jumpRow: {
+    gap: spacing.sm,
+  },
+  input: {
+    height: 44,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.medium,
+    backgroundColor: semanticColors.tertiarySystemFill,
+    color: semanticColors.label,
+    fontSize: 17,
+    fontVariant: ['tabular-nums'],
+  },
+  inputError: {
+    paddingLeft: spacing.xs,
+  },
+  footer: {
+    paddingHorizontal: nativeMetrics.screenGutter,
+    paddingTop: spacing.md,
+    paddingBottom: nativeMetrics.screenGutter,
+  },
+  tabular: {
+    fontVariant: ['tabular-nums'],
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+});

--- a/apps/mobile/app/(tabs)/overview/period.tsx
+++ b/apps/mobile/app/(tabs)/overview/period.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -19,6 +19,7 @@ import {
 import {
   formatDateValue,
   parseDateValue,
+  resolveDashboardPeriod,
   shiftDashboardPeriodDays,
   shiftDashboardPeriodMonths,
 } from '@/lib/dashboard-period';
@@ -79,8 +80,13 @@ export default function DashboardPeriodScreen() {
   const router = useRouter();
   const [dateValue, setDateValue] = useState(() => getDashboardPeriodValue() ?? todayDateValue());
   const todayValue = todayDateValue();
+  const today = useMemo(() => parseDateValue(todayValue)!, [todayValue]);
+  const parsedDate = parseDateValue(dateValue);
   const isToday = dateValue === todayValue;
-  const dateLabel = formatDateValue(parseDateValue(dateValue) ?? new Date());
+  const isValidDate = parsedDate !== null;
+  const isFutureDate = Boolean(parsedDate && parsedDate > today);
+  const canCommit = isValidDate && !isFutureDate;
+  const dateLabel = formatDateValue(parsedDate ?? today);
   const snapshotLabel = isToday
     ? { text: 'Live snapshot', color: 'positive' as TextColor }
     : { text: 'Historical snapshot', color: 'attention' as TextColor };
@@ -89,7 +95,11 @@ export default function DashboardPeriodScreen() {
     : `Spend and rewards as they stood on ${dateLabel}.`;
 
   const commit = () => {
-    setDashboardPeriodValue(dateValue);
+    if (!canCommit || !parsedDate) {
+      return;
+    }
+    const resolved = resolveDashboardPeriod(formatDateValue(parsedDate));
+    setDashboardPeriodValue(resolved.isToday ? undefined : resolved.dateValue);
     router.back();
   };
 
@@ -109,11 +119,17 @@ export default function DashboardPeriodScreen() {
   const dayLabel = dateValue === todayValue
     ? 'Today'
     : new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'short' })
-      .format(parseDateValue(dateValue) ?? new Date());
+      .format(parsedDate ?? today);
   const monthLabel = new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' })
-    .format(parseDateValue(dateValue) ?? new Date());
-  const canStepForward = !isToday;
-  const canGoEarlier = parseDateValue(dateValue) !== null;
+    .format(parsedDate ?? today);
+  const canStepForward = !isToday && canCommit;
+  const inputError = !dateValue
+    ? 'Enter a date on or before today'
+    : !isValidDate
+      ? 'Use YYYY-MM-DD format'
+      : isFutureDate
+        ? 'Choose a date on or before today'
+        : undefined;
 
   return (
     <>
@@ -182,9 +198,9 @@ export default function DashboardPeriodScreen() {
                   accessibilityLabel="Date in YYYY-MM-DD format"
                   style={styles.input}
                 />
-                {!canGoEarlier ? (
+                {inputError ? (
                   <Footnote color="attention" style={styles.inputError}>
-                    Enter a date on or before today
+                    {inputError}
                   </Footnote>
                 ) : null}
               </View>
@@ -197,7 +213,7 @@ export default function DashboardPeriodScreen() {
             variant="filled"
             size="large"
             onPress={commit}
-            disabled={!canGoEarlier}
+            disabled={!canCommit}
             accessibilityHint="Shows the dashboard as it stood on the selected date"
           >
             View this date

--- a/apps/mobile/app/(tabs)/preferences/data.tsx
+++ b/apps/mobile/app/(tabs)/preferences/data.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
@@ -16,8 +16,48 @@ type Message = { text: string; tone: 'positive' | 'attention' };
 
 export default function DataPreferencesScreen() {
   const router = useRouter();
-  const { actions } = useStorage();
+  const { state, actions } = useStorage();
   const [message, setMessage] = useState<Message>();
+
+  const trackedIds = useMemo(
+    () => new Set(state.trackedAccountIds),
+    [state.trackedAccountIds],
+  );
+  const orphanedCards = useMemo(
+    () => (state.trackedAccountIds.length > 0
+      ? state.cards.filter((card) => !trackedIds.has(card.ynabAccountId))
+      : []),
+    [state.cards, state.trackedAccountIds.length, trackedIds],
+  );
+
+  const clearOrphans = () => {
+    Alert.alert(
+      'Remove orphaned cards?',
+      `${orphanedCards.length} card${orphanedCards.length === 1 ? '' : 's'} reference${orphanedCards.length === 1 ? 's' : ''} YNAB ${orphanedCards.length === 1 ? 'account' : 'accounts'} that ${orphanedCards.length === 1 ? 'is' : 'are'} no longer tracked. Their reward settings will be removed, and tracking the account again creates a fresh card.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              const kept = state.cards.filter((card) => trackedIds.has(card.ynabAccountId));
+              await actions.setCards(kept);
+              setMessage({
+                text: `${orphanedCards.length} orphaned card${orphanedCards.length === 1 ? '' : 's'} removed`,
+                tone: 'positive',
+              });
+            })().catch((error: unknown) => {
+              setMessage({
+                text: error instanceof Error ? error.message : 'Couldn’t remove orphaned cards',
+                tone: 'attention',
+              });
+            });
+          },
+        },
+      ],
+    );
+  };
 
   const exportData = async () => {
     try {
@@ -129,8 +169,19 @@ export default function DataPreferencesScreen() {
       <View>
         <SectionHeader>ON THIS IPHONE</SectionHeader>
         <Card>
+          {orphanedCards.length > 0 ? (
+            <SettingsRow
+              isFirst={orphanedCards.length > 0}
+              title="Remove orphaned cards"
+              subtitle={`${orphanedCards.length} card${orphanedCards.length === 1 ? '' : 's'} from ${orphanedCards.length === 1 ? 'an account' : 'accounts'} no longer tracked`}
+              symbol="wand.and.stars"
+              symbolColor={semanticColors.attention}
+              destructive
+              onPress={clearOrphans}
+            />
+          ) : null}
           <SettingsRow
-            isFirst
+            isFirst={orphanedCards.length === 0}
             title="Erase all local data"
             subtitle="Return the app to first-run setup"
             symbol="trash.fill"

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -91,6 +91,10 @@ function AppShell() {
             name="card/[id]/edit"
             options={{ headerShown: true, title: 'Edit card', presentation: 'formSheet' }}
           />
+          <Stack.Screen
+            name="card/[id]/transactions"
+            options={{ headerShown: true, title: 'Transactions' }}
+          />
         </Stack>
       </ThemeProvider>
       <StatusBar style={activeScheme === 'dark' ? 'light' : 'dark'} />

--- a/apps/mobile/app/card/[id]/index.tsx
+++ b/apps/mobile/app/card/[id]/index.tsx
@@ -660,6 +660,14 @@ export default function CardDetailScreen() {
             subtitle={cardTransactions.length > 0
               ? `${cardTransactions.length} most recent saved ${cardTransactions.length === 1 ? 'transaction' : 'transactions'}`
               : undefined}
+            action={cardTransactions.length > 0 ? {
+              label: 'View all',
+              onPress: () => router.push({
+                pathname: '/card/[id]/transactions',
+                params: { id: card.id },
+              }),
+              accessibilityHint: 'Opens every saved transaction for this card',
+            } : undefined}
           />
           {cardTransactions.length > 0 ? (
             <View style={styles.group}>

--- a/apps/mobile/app/card/[id]/transactions.tsx
+++ b/apps/mobile/app/card/[id]/transactions.tsx
@@ -43,11 +43,14 @@ export default function CardTransactionsScreen() {
   const activity = useActivityModel('', accountId);
 
   const cardTransactions = useMemo(() => {
-    if (!card || !accountId) {
+    if (!card || !cardId) {
       return [];
     }
-    return activity.transactions;
-  }, [accountId, activity.transactions, card]);
+    // Prefer card id so shared YNAB accounts cannot leak another card's rows.
+    return activity.transactions.filter(
+      (projection) => projection.card?.id === cardId,
+    );
+  }, [activity.transactions, card, cardId]);
 
   const sections = useMemo(
     () => groupActivityByDate(cardTransactions),

--- a/apps/mobile/app/card/[id]/transactions.tsx
+++ b/apps/mobile/app/card/[id]/transactions.tsx
@@ -1,0 +1,212 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  RefreshControl,
+  SectionList,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+
+import {
+  EmptyState,
+  LargeNavigationTitle,
+  SyncBadge,
+} from '@/components/native';
+import { Footnote, Headline } from '@/components/ios';
+import { useStorage } from '@/contexts/StorageContext';
+import {
+  TransactionRow,
+  groupActivityByDate,
+  useActivityModel,
+  type ActivitySection,
+} from '@/features/activity';
+import { useRewardsDashboard } from '@/features/cards/dashboard';
+import { semanticColors } from '@/theme';
+import { nativeMetrics, radii, spacing } from '@/theme/tokens';
+import type { TransactionProjection } from '@ynab-counter/app-core/rewards-engine';
+
+function parameterValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default function CardTransactionsScreen() {
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const cardId = parameterValue(params.id);
+  const router = useRouter();
+  const { state } = useStorage();
+  const model = useRewardsDashboard();
+
+  const card = useMemo(
+    () => state.cards.find((candidate) => candidate.id === cardId),
+    [cardId, state.cards],
+  );
+  const accountId = card?.ynabAccountId;
+  const activity = useActivityModel('', accountId);
+
+  const cardTransactions = useMemo(
+    () => activity.transactions,
+    [activity.transactions],
+  );
+
+  const sections = useMemo(
+    () => groupActivityByDate(cardTransactions),
+    [cardTransactions],
+  );
+
+  const openTransaction = useCallback((id: string) => {
+    router.push({
+      pathname: '/(tabs)/activity/[id]',
+      params: { id },
+    });
+  }, [router]);
+
+  const renderTransaction = useCallback(({
+    item,
+    index,
+    section,
+  }: {
+    item: TransactionProjection;
+    index: number;
+    section: ActivitySection;
+  }) => {
+    const isFirst = index === 0;
+    const isLast = index === section.data.length - 1;
+    const position = isFirst && isLast
+      ? 'only'
+      : isFirst
+        ? 'first'
+        : isLast
+          ? 'last'
+          : 'middle';
+
+    return (
+      <TransactionRow
+        projection={item}
+        settings={state.settings}
+        position={position}
+        onPress={() => openTransaction(item.transaction.id)}
+      />
+    );
+  }, [openTransaction, state.settings]);
+
+  const isCardRefreshing = model.isRefreshing;
+  const refresh = model.canSync
+    ? model.refresh
+    : () => router.push('/settings');
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: card?.name ?? 'Transactions',
+        }}
+      />
+      <SectionList<TransactionProjection, ActivitySection>
+        style={styles.screen}
+        sections={sections}
+        keyExtractor={(item) => item.transaction.id}
+        renderItem={renderTransaction}
+        renderSectionHeader={({ section }) => (
+          <View style={styles.sectionHeader}>
+            <Headline accessibilityRole="header">{section.title}</Headline>
+            <Footnote color="secondary">
+              {section.data.length} {section.data.length === 1 ? 'transaction' : 'transactions'}
+            </Footnote>
+          </View>
+        )}
+        renderSectionFooter={() => <View style={styles.sectionFooter} />}
+        ListHeaderComponent={(
+          <View style={styles.topMatter}>
+            <LargeNavigationTitle>Transactions</LargeNavigationTitle>
+            <View style={styles.orientation}>
+              <Footnote color="secondary">
+                {cardTransactions.length} saved {cardTransactions.length === 1 ? 'transaction' : 'transactions'}
+              </Footnote>
+              <SyncBadge
+                state={model.syncState}
+                label={model.syncLabel}
+                onPress={refresh}
+                accessibilityHint={model.canSync
+                  ? 'Refreshes transactions from YNAB'
+                  : 'Opens YNAB connection settings'}
+              />
+            </View>
+          </View>
+        )}
+        ListEmptyComponent={(
+          <EmptyState
+            compact
+            title="No saved transactions yet"
+            message="Pull down to fetch transactions for this card."
+            action={model.canSync
+              ? {
+                  label: 'Refresh transactions',
+                  onPress: model.refresh,
+                  accessibilityHint: 'Fetches transactions from YNAB',
+                }
+              : undefined}
+          />
+        )}
+        refreshControl={(
+          <RefreshControl
+            refreshing={isCardRefreshing}
+            onRefresh={model.refresh}
+            enabled={model.canSync}
+            tintColor={semanticColors.action}
+            accessibilityLabel="Refresh card transactions"
+          />
+        )}
+        contentInsetAdjustmentBehavior="automatic"
+        automaticallyAdjustsScrollIndicatorInsets
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        stickySectionHeadersEnabled
+        contentContainerStyle={[
+          styles.content,
+          sections.length === 0 && styles.emptyContent,
+        ]}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: semanticColors.systemGroupedBackground,
+  },
+  content: {
+    paddingBottom: spacing.xxxl,
+  },
+  emptyContent: {
+    flexGrow: 1,
+  },
+  topMatter: {
+    paddingHorizontal: nativeMetrics.screenGutter,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+    gap: spacing.md,
+  },
+  orientation: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  sectionHeader: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    paddingHorizontal: nativeMetrics.screenGutter,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+    backgroundColor: semanticColors.systemGroupedBackground,
+  },
+  sectionFooter: {
+    height: spacing.sm,
+  },
+});

--- a/apps/mobile/app/card/[id]/transactions.tsx
+++ b/apps/mobile/app/card/[id]/transactions.tsx
@@ -9,7 +9,6 @@ import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 
 import {
   EmptyState,
-  LargeNavigationTitle,
   SyncBadge,
 } from '@/components/native';
 import { Footnote, Headline } from '@/components/ios';
@@ -22,7 +21,7 @@ import {
 } from '@/features/activity';
 import { useRewardsDashboard } from '@/features/cards/dashboard';
 import { semanticColors } from '@/theme';
-import { nativeMetrics, radii, spacing } from '@/theme/tokens';
+import { nativeMetrics, spacing } from '@/theme/tokens';
 import type { TransactionProjection } from '@ynab-counter/app-core/rewards-engine';
 
 function parameterValue(value: string | string[] | undefined): string | undefined {
@@ -43,10 +42,12 @@ export default function CardTransactionsScreen() {
   const accountId = card?.ynabAccountId;
   const activity = useActivityModel('', accountId);
 
-  const cardTransactions = useMemo(
-    () => activity.transactions,
-    [activity.transactions],
-  );
+  const cardTransactions = useMemo(() => {
+    if (!card || !accountId) {
+      return [];
+    }
+    return activity.transactions;
+  }, [accountId, activity.transactions, card]);
 
   const sections = useMemo(
     () => groupActivityByDate(cardTransactions),
@@ -94,11 +95,30 @@ export default function CardTransactionsScreen() {
     ? model.refresh
     : () => router.push('/settings');
 
+  if (!card || !accountId) {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Transactions' }} />
+        <View style={[styles.screen, styles.missingCard]}>
+          <EmptyState
+            title="Card not found"
+            message="This card is no longer available."
+            action={{
+              label: 'Back to cards',
+              onPress: () => router.replace('/(tabs)/cards'),
+              accessibilityHint: 'Returns to the cards list',
+            }}
+          />
+        </View>
+      </>
+    );
+  }
+
   return (
     <>
       <Stack.Screen
         options={{
-          title: card?.name ?? 'Transactions',
+          title: card.name,
         }}
       />
       <SectionList<TransactionProjection, ActivitySection>
@@ -117,7 +137,6 @@ export default function CardTransactionsScreen() {
         renderSectionFooter={() => <View style={styles.sectionFooter} />}
         ListHeaderComponent={(
           <View style={styles.topMatter}>
-            <LargeNavigationTitle>Transactions</LargeNavigationTitle>
             <View style={styles.orientation}>
               <Footnote color="secondary">
                 {cardTransactions.length} saved {cardTransactions.length === 1 ? 'transaction' : 'transactions'}
@@ -174,6 +193,10 @@ const styles = StyleSheet.create({
   screen: {
     flex: 1,
     backgroundColor: semanticColors.systemGroupedBackground,
+  },
+  missingCard: {
+    justifyContent: 'center',
+    paddingHorizontal: nativeMetrics.screenGutter,
   },
   content: {
     paddingBottom: spacing.xxxl,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "ios": "pnpm exec expo run:ios",
     "android": "pnpm exec expo start --android",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "test": "vitest run src/storage/service.test.ts src/features/activity/flag-update.integration.test.ts src/features/activity/flag-update.test.ts src/features/cards/card-edit-publication.integration.test.ts src/features/cards/card-edit-refresh.test.ts src/features/cards/local-day-clock.test.ts src/features/cards/reward-categories.test.ts src/features/preferences/currency-sample.test.ts src/contexts/setup-sync-chain.test.ts src/lib/cloud-sync-key.test.ts src/lib/cloud-sync-revision.test.ts"
+    "test": "vitest run src/storage/service.test.ts src/features/activity/flag-update.integration.test.ts src/features/activity/flag-update.test.ts src/features/cards/card-edit-publication.integration.test.ts src/features/cards/card-edit-refresh.test.ts src/features/cards/local-day-clock.test.ts src/features/cards/reward-categories.test.ts src/features/preferences/currency-sample.test.ts src/contexts/setup-sync-chain.test.ts src/lib/cloud-sync-key.test.ts src/lib/cloud-sync-revision.test.ts src/lib/dashboard-period.test.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.25.0",

--- a/apps/mobile/src/components/native/CardStatusRow.tsx
+++ b/apps/mobile/src/components/native/CardStatusRow.tsx
@@ -6,10 +6,11 @@ import {
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
-import { Body, Footnote, Headline } from '../ios/Typography';
+import { SymbolView } from 'expo-symbols';
+import { Body, Caption1, Footnote, Headline } from '../ios/Typography';
 import { BrandMark } from '../brand';
 import { useHaptics } from '../../hooks/useHaptics';
-import { semanticColors } from '../../theme/semanticColors';
+import { semanticColors, withAlpha } from '../../theme/semanticColors';
 import { interaction, nativeMetrics, radii, spacing } from '../../theme/tokens';
 import { MetricValue } from './MetricValue';
 import { ProgressRail } from './ProgressRail';
@@ -38,6 +39,8 @@ export interface CardStatusRowProps {
   minimumSpend?: number | null;
   maximumSpend?: number | null;
   status?: CardTrackingStatus | CardStatusDescriptor;
+  promo?: boolean;
+  ruleCount?: number;
   onPress?: () => void;
   disabled?: boolean;
   showBrandMark?: boolean;
@@ -101,6 +104,8 @@ export function CardStatusRow({
   minimumSpend,
   maximumSpend,
   status,
+  promo = false,
+  ruleCount = 0,
   onPress,
   disabled = false,
   showBrandMark = true,
@@ -125,6 +130,11 @@ export function CardStatusRow({
     hasMaximum ? `cap ${formatValue(maximumSpend)}` : undefined,
   ].filter((value): value is string => Boolean(value)).join(', ');
 
+  const badges = [
+    promo ? 'promotional period active' : undefined,
+    ruleCount > 0 ? `${ruleCount} flag ${ruleCount === 1 ? 'rule' : 'rules'}` : undefined,
+  ].filter((value): value is string => Boolean(value));
+
   const resolvedAccessibilityLabel = accessibilityLabel ?? [
     name,
     issuer,
@@ -133,6 +143,7 @@ export function CardStatusRow({
     `spent ${formatValue(spend)}`,
     resolvedStatus.label,
     thresholdLabel || undefined,
+    ...badges,
   ].filter(Boolean).join(', ');
 
   const content = (
@@ -153,6 +164,38 @@ export function CardStatusRow({
         </View>
 
         <View style={styles.trailing}>
+          {promo ? (
+            <View
+              style={styles.promoPill}
+              accessible={!groupsAccessibilityContent}
+              accessibilityLabel="Promotional period active"
+            >
+              <SymbolView
+                name="sparkles"
+                size={10}
+                tintColor={semanticColors.systemPurple}
+                accessibilityElementsHidden
+              />
+              <Caption1 style={styles.promoText} accessible={false}>Promo</Caption1>
+            </View>
+          ) : null}
+          {ruleCount > 0 ? (
+            <View
+              style={styles.rulePill}
+              accessible={!groupsAccessibilityContent}
+              accessibilityLabel={`${ruleCount} flag ${ruleCount === 1 ? 'rule' : 'rules'}`}
+            >
+              <SymbolView
+                name="tag"
+                size={10}
+                tintColor={semanticColors.secondaryLabel}
+                accessibilityElementsHidden
+              />
+              <Caption1 color="secondary" style={styles.ruleText} accessible={false}>
+                {ruleCount} {ruleCount === 1 ? 'rule' : 'rules'}
+              </Caption1>
+            </View>
+          ) : null}
           {showsStatus ? (
             <StatusPill
               label={resolvedStatus.label}
@@ -283,7 +326,36 @@ const styles = StyleSheet.create({
   trailing: {
     flexDirection: 'row',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
     gap: spacing.sm,
+  },
+  promoPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radii.pill,
+    backgroundColor: withAlpha('#AF52DE', '1F'),
+  },
+  promoText: {
+    color: semanticColors.systemPurple,
+    fontWeight: '600',
+    fontSize: 11,
+  },
+  rulePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.tertiarySystemFill,
+  },
+  ruleText: {
+    fontWeight: '600',
+    fontSize: 11,
   },
   disclosure: {
     fontSize: 25,

--- a/apps/mobile/src/components/native/CardStatusRow.tsx
+++ b/apps/mobile/src/components/native/CardStatusRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Pressable,
   StyleSheet,
+  Text,
   View,
   type StyleProp,
   type ViewStyle,
@@ -175,6 +176,7 @@ export function CardStatusRow({
                 size={10}
                 tintColor={semanticColors.systemPurple}
                 accessibilityElementsHidden
+                fallback={<Text style={styles.promoFallback}>*</Text>}
               />
               <Caption1 style={styles.promoText} accessible={false}>Promo</Caption1>
             </View>
@@ -190,6 +192,7 @@ export function CardStatusRow({
                 size={10}
                 tintColor={semanticColors.secondaryLabel}
                 accessibilityElementsHidden
+                fallback={<Text style={styles.ruleFallback}>#</Text>}
               />
               <Caption1 color="secondary" style={styles.ruleText} accessible={false}>
                 {ruleCount} {ruleCount === 1 ? 'rule' : 'rules'}
@@ -344,6 +347,11 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     fontSize: 11,
   },
+  promoFallback: {
+    color: semanticColors.systemPurple,
+    fontSize: 10,
+    fontWeight: '700',
+  },
   rulePill: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -356,6 +364,11 @@ const styles = StyleSheet.create({
   ruleText: {
     fontWeight: '600',
     fontSize: 11,
+  },
+  ruleFallback: {
+    color: semanticColors.secondaryLabel,
+    fontSize: 10,
+    fontWeight: '700',
   },
   disclosure: {
     fontSize: 25,

--- a/apps/mobile/src/features/activity/model.ts
+++ b/apps/mobile/src/features/activity/model.ts
@@ -203,7 +203,7 @@ function matchesQuery(projection: TransactionProjection, query: string): boolean
     .some((value) => value.toLocaleLowerCase('en-GB').includes(normalized));
 }
 
-export function useActivityModel(query = ''): ActivityModel {
+export function useActivityModel(query = '', accountId?: string): ActivityModel {
   const { state, status, actions } = useStorage();
   const [currentTimestamp, setCurrentTimestamp] = useState(() => Date.now());
   useEffect(() => {
@@ -246,8 +246,12 @@ export function useActivityModel(query = ''): ActivityModel {
     [accountNames, cacheEntry, state.cards, state.settings, trackedAccounts],
   );
   const transactions = useMemo(
-    () => projected.filter((projection) => matchesQuery(projection, query)),
-    [projected, query],
+    () => projected
+      .filter((projection) => (
+        !accountId || projection.transaction.account_id === accountId
+      ))
+      .filter((projection) => matchesQuery(projection, query)),
+    [accountId, projected, query],
   );
   const sections = useMemo(
     () => groupActivityByDate(transactions, new Date(currentTimestamp)),

--- a/apps/mobile/src/features/activity/model.ts
+++ b/apps/mobile/src/features/activity/model.ts
@@ -245,14 +245,15 @@ export function useActivityModel(query = '', accountId?: string): ActivityModel 
       .sort((left, right) => right.transaction.date.localeCompare(left.transaction.date)),
     [accountNames, cacheEntry, state.cards, state.settings, trackedAccounts],
   );
-  const transactions = useMemo(
-    () => projected
-      .filter((projection) => (
-        !accountId || projection.transaction.account_id === accountId
-      ))
-      .filter((projection) => matchesQuery(projection, query)),
-    [accountId, projected, query],
-  );
+  const transactions = useMemo(() => {
+    // Callers that pass `accountId` intentionally scope to one account. An
+    // explicit empty string (or other falsy sentinels after narrowing) must not
+    // fall through to the full ledger — only `undefined` means "all accounts".
+    const scoped = accountId === undefined
+      ? projected
+      : projected.filter((projection) => projection.transaction.account_id === accountId);
+    return scoped.filter((projection) => matchesQuery(projection, query));
+  }, [accountId, projected, query]);
   const sections = useMemo(
     () => groupActivityByDate(transactions, new Date(currentTimestamp)),
     [currentTimestamp, transactions],

--- a/apps/mobile/src/features/cards/dashboard.ts
+++ b/apps/mobile/src/features/cards/dashboard.ts
@@ -303,13 +303,18 @@ export function useRewardsDashboard(referenceDate?: Date): RewardsDashboardModel
   );
 
   const visibleCards = useMemo(() => {
+    // Hide-until-next-cycle is a live-period affordance. Historical snapshots
+    // include those cards so tiles, status totals, and recommendations match.
+    if (referenceDate) {
+      return orderedCards.filter(({ card }) => card.featured !== false);
+    }
     const hidden = new Set(
       state.hiddenCards
         .filter((entry) => isHiddenAt(entry.cardId, entry.hiddenUntil, asOf))
         .map((entry) => entry.cardId),
     );
     return orderedCards.filter(({ card }) => card.featured !== false && !hidden.has(card.id));
-  }, [asOf, orderedCards, state.hiddenCards]);
+  }, [asOf, orderedCards, referenceDate, state.hiddenCards]);
 
   const attentionCards = useMemo(
     () => visibleCards.filter((projection) => ATTENTION_STATUSES.has(projection.status)),

--- a/apps/mobile/src/features/cards/presentation.ts
+++ b/apps/mobile/src/features/cards/presentation.ts
@@ -46,6 +46,39 @@ export function createCardFormatting(settings: AppSettings): CardFormatting {
   };
 }
 
+function formatLocalDay(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Whether a card's promotional window includes the reference day.
+ * `startDate` may be null (open-ended start); only a parseable end date is required.
+ */
+export function isPromotionalPeriodActive(
+  card: Pick<CreditCard, 'promotionalPeriod'>,
+  referenceDate: Date = new Date(),
+): boolean {
+  const promo = card.promotionalPeriod;
+  if (!promo?.endDate || !/^\d{4}-\d{2}-\d{2}$/.test(promo.endDate)) {
+    return false;
+  }
+  const day = formatLocalDay(referenceDate);
+  if (typeof promo.startDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(promo.startDate) && day < promo.startDate) {
+    return false;
+  }
+  return day <= promo.endDate;
+}
+
+export function countActiveFlagRules(card: Pick<CreditCard, 'subcategoriesEnabled' | 'subcategories'>): number {
+  if (!card.subcategoriesEnabled) {
+    return 0;
+  }
+  return (card.subcategories ?? []).filter((subcategory) => subcategory.active !== false).length;
+}
+
 export function formatReward(
   projection: Pick<CardDashboardProjection, 'reward'>,
   formatting: CardFormatting,

--- a/apps/mobile/src/features/overview/card-group.tsx
+++ b/apps/mobile/src/features/overview/card-group.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Pressable, StyleSheet, View, type ColorValue } from 'react-native';
+import { SymbolView } from 'expo-symbols';
+
+import { Headline, Title2 } from '@/components/ios';
+import { semanticColors } from '@/theme';
+import { interaction, nativeMetrics, spacing } from '@/theme/tokens';
+
+export interface CardGroupHeaderProps {
+  title: string;
+  count: number;
+  icon: 'percent' | 'chart.line.uptrend.xyaxis';
+  iconColor: ColorValue | undefined;
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Collapsible section header for the type-grouped dashboard grid, mirroring
+ * the web dashboard's cashback/miles groups with count badges.
+ */
+export function CardGroupHeader({
+  title,
+  count,
+  icon,
+  iconColor,
+  collapsed,
+  onToggle,
+}: CardGroupHeaderProps) {
+  return (
+    <Pressable
+      onPress={onToggle}
+      accessibilityRole="button"
+      accessibilityLabel={`${title}, ${count} ${count === 1 ? 'card' : 'cards'}`}
+      accessibilityState={{ expanded: !collapsed }}
+      accessibilityHint={collapsed ? 'Expands this group' : 'Collapses this group'}
+      style={({ pressed }) => [styles.header, pressed && styles.pressed]}
+    >
+      <View style={styles.identity}>
+        <SymbolView
+          name={icon}
+          size={15}
+          tintColor={iconColor}
+          style={styles.icon}
+          accessibilityElementsHidden
+        />
+        <Headline accessible={false}>{title}</Headline>
+      </View>
+      <View style={styles.trailing}>
+        <Title2 color="secondary" style={styles.count} accessible={false}>
+          {count}
+        </Title2>
+        <SymbolView
+          name="chevron.down"
+          size={12}
+          tintColor={semanticColors.tertiaryLabel}
+          style={collapsed && styles.chevronCollapsed}
+          accessibilityElementsHidden
+        />
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+    paddingVertical: spacing.xs,
+  },
+  identity: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  icon: {
+    flexShrink: 0,
+  },
+  trailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  count: {
+    fontVariant: ['tabular-nums'],
+  },
+  chevronCollapsed: {
+    transform: [{ rotate: '-90deg' }],
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+});

--- a/apps/mobile/src/features/overview/card-tile.tsx
+++ b/apps/mobile/src/features/overview/card-tile.tsx
@@ -10,6 +10,7 @@ import { SymbolView } from 'expo-symbols';
 
 import { Caption1, Footnote, Headline, Title3 } from '@/components/ios';
 import type { CardFormatting } from '@/features/cards/presentation';
+import { isPromotionalPeriodActive } from '@/features/cards/presentation';
 import { semanticColors, withAlpha } from '@/theme';
 import { interaction, radii, spacing } from '@/theme/tokens';
 import type { TextColor } from '@/components/ios/Typography';
@@ -45,6 +46,7 @@ function cardUsesBlocks(card: CreditCard): boolean {
 export interface CardTileProps {
   projection: CardDashboardProjection;
   formatting: CardFormatting;
+  referenceDate?: Date;
   allowHideCard: boolean;
   isSubcategoryExpanded: boolean;
   onToggleSubcategories: () => void;
@@ -61,6 +63,7 @@ export interface CardTileProps {
 export function CardTile({
   projection,
   formatting,
+  referenceDate,
   allowHideCard,
   isSubcategoryExpanded,
   onToggleSubcategories,
@@ -68,7 +71,8 @@ export function CardTile({
   onOpen,
   style,
 }: CardTileProps) {
-  const { card, period } = projection;
+  const { card } = projection;
+  const promoActive = isPromotionalPeriodActive(card, referenceDate);
   const hasBlockRounding = cardUsesBlocks(card);
   const displayedSpend = hasBlockRounding ? projection.spend.counted : projection.spend.total;
   const hasMinimum = projection.minimum.target !== null;
@@ -124,12 +128,12 @@ export function CardTile({
             : 'spent';
     const label =
       variant === 'cap-left'
-        ? `${remainingToMaximum.toFixed(2)} left before the cap`
+        ? `${formatting.currencyRounded(remainingToMaximum)} left before the cap`
         : variant === 'cap-over'
-          ? `${exceededAmount.toFixed(2)} over the cap`
+          ? `${formatting.currencyRounded(exceededAmount)} over the cap`
           : variant === 'min-left'
-            ? `${remainingToMinimum.toFixed(2)} more to meet the minimum`
-            : `Spent ${displayedSpend.toFixed(2)} this period`;
+            ? `${formatting.currencyRounded(remainingToMinimum)} more to meet the minimum`
+            : `Spent ${formatting.currencyRounded(displayedSpend)} this period`;
     return {
       variant,
       amount,
@@ -142,6 +146,7 @@ export function CardTile({
     displayedSpend,
     exceeded,
     exceededAmount,
+    formatting,
     hasMaximum,
     hasMinimum,
     minimumMet,
@@ -176,11 +181,9 @@ export function CardTile({
   const daysRemaining = projection.daysRemaining;
   const daysTone: TextColor = daysRemaining <= 1
     ? 'destructive'
-    : daysRemaining <= 3
+    : daysRemaining <= 7
       ? 'attention'
-      : daysRemaining <= 7
-        ? 'attention'
-        : 'tertiary';
+      : 'tertiary';
   const daysLabel = `${daysRemaining}d`;
 
   const blockCount = projection.blockInfo?.blocksEarned ?? null;
@@ -230,7 +233,7 @@ export function CardTile({
         <View style={styles.header} accessibilityElementsHidden>
           <Headline numberOfLines={1} style={styles.cardName}>{card.name}</Headline>
           <View style={styles.headerTrailing}>
-            {card.promotionalPeriod ? (
+            {promoActive ? (
               <View style={styles.promoPill}>
                 <SymbolView
                   name="sparkles"
@@ -303,6 +306,7 @@ export function CardTile({
           minimumProgressSpend={projection.progress.minimumProgressSpend}
           maximumProgressSpend={projection.progress.maximumProgressSpend}
           height={8}
+          formatAmount={formatting.currencyRounded}
           accessible={false}
         />
 
@@ -344,7 +348,7 @@ export function CardTile({
 
       {allowHideCard && exceeded ? (
         <Pressable
-          onPress={() => onHideCard(card.id, period.end)}
+          onPress={() => onHideCard(card.id, projection.resetsOn)}
           accessibilityRole="button"
           accessibilityLabel={`Hide ${card.name} until next cycle`}
           style={({ pressed }) => [styles.hideButton, pressed && styles.pressed]}

--- a/apps/mobile/src/features/overview/card-tile.tsx
+++ b/apps/mobile/src/features/overview/card-tile.tsx
@@ -10,7 +10,6 @@ import { SymbolView } from 'expo-symbols';
 
 import { Caption1, Footnote, Headline, Title3 } from '@/components/ios';
 import type { CardFormatting } from '@/features/cards/presentation';
-import { formatResetDate } from '@/features/cards/presentation';
 import { semanticColors, withAlpha } from '@/theme';
 import { interaction, radii, spacing } from '@/theme/tokens';
 import type { TextColor } from '@/components/ios/Typography';
@@ -69,7 +68,7 @@ export function CardTile({
   onOpen,
   style,
 }: CardTileProps) {
-  const { card, calculation, period } = projection;
+  const { card, period } = projection;
   const hasBlockRounding = cardUsesBlocks(card);
   const displayedSpend = hasBlockRounding ? projection.spend.counted : projection.spend.total;
   const hasMinimum = projection.minimum.target !== null;
@@ -219,7 +218,7 @@ export function CardTile({
       : { borderColor: semanticColors.separator, borderWidth: StyleSheet.hairlineWidth };
 
   return (
-    <View style={[styles.tile, borderTone, style]} accessibilityElementsHidden>
+    <View style={[styles.tile, borderTone, style]}>
       <Pressable
         onPress={onOpen}
         accessible
@@ -228,61 +227,44 @@ export function CardTile({
         accessibilityHint="Opens card details"
         style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
       >
-        <View style={styles.header}>
+        <View style={styles.header} accessibilityElementsHidden>
           <Headline numberOfLines={1} style={styles.cardName}>{card.name}</Headline>
           <View style={styles.headerTrailing}>
             {card.promotionalPeriod ? (
-              <View style={styles.promoPill} accessible accessibilityLabel={`Promotional period until ${formatResetDate(card.promotionalPeriod.endDate)}`}>
+              <View style={styles.promoPill}>
                 <SymbolView
                   name="sparkles"
                   size={11}
                   tintColor={semanticColors.systemPurple}
-                  accessibilityElementsHidden
                 />
-                <Caption1 color="action" style={styles.promoText} accessible={false}>Promo</Caption1>
+                <Caption1 color="action" style={styles.promoText}>Promo</Caption1>
               </View>
             ) : null}
-            <View
-              accessible
-              accessibilityRole="text"
-              accessibilityLabel={
-                card.type === 'cashback'
-                  ? `Earned ${earnedDisplay} cashback`
-                  : `Earned ${earnedDisplay} miles`
-              }
-              style={styles.rewardChip}
-            >
+            <View style={styles.rewardChip}>
               <SymbolView
                 name={card.type === 'cashback' ? 'dollarsign.circle.fill' : 'airplane'}
                 size={14}
                 tintColor={rewardChipColor}
                 style={styles.rewardIcon}
-                accessibilityElementsHidden
               />
-              <Footnote color={rewardChipTone} style={styles.rewardChipText} accessible={false}>
+              <Footnote color={rewardChipTone} style={styles.rewardChipText}>
                 {earnedDisplay}
               </Footnote>
             </View>
           </View>
         </View>
 
-        <View style={styles.heroRow}>
-          <Caption1 color="secondary" style={styles.heroLabel} accessible={false}>
+        <View style={styles.heroRow} accessibilityElementsHidden>
+          <Caption1 color="secondary" style={styles.heroLabel}>
             {heroLabel}
           </Caption1>
-          <View
-            accessible
-            accessibilityRole="text"
-            accessibilityLabel={hero.label}
-            style={styles.heroValueRow}
-          >
+          <View style={styles.heroValueRow}>
             {hero.variant === 'min-left' ? (
               <SymbolView
                 name="arrow.up.right"
                 size={13}
                 tintColor={semanticColors.attention}
                 style={styles.heroGlyph}
-                accessibilityElementsHidden
               />
             ) : hero.variant === 'cap-left' ? (
               <SymbolView
@@ -290,7 +272,6 @@ export function CardTile({
                 size={13}
                 tintColor={semanticColors.positive}
                 style={styles.heroGlyph}
-                accessibilityElementsHidden
               />
             ) : hero.variant === 'cap-over' ? (
               <SymbolView
@@ -298,20 +279,17 @@ export function CardTile({
                 size={13}
                 tintColor={semanticColors.destructive}
                 style={styles.heroGlyph}
-                accessibilityElementsHidden
               />
             ) : null}
             <Title3
               color={hero.tone}
               style={[styles.heroNumber, hero.weight === 'medium' && styles.heroNumberMedium]}
-              accessible={false}
             >
               {heroNumberText}
             </Title3>
             <Caption1
               color={hero.variant === 'spent' ? 'secondary' : hero.tone}
               style={styles.heroSuffix}
-              accessible={false}
             >
               {hero.suffix}
             </Caption1>
@@ -325,7 +303,7 @@ export function CardTile({
           minimumProgressSpend={projection.progress.minimumProgressSpend}
           maximumProgressSpend={projection.progress.maximumProgressSpend}
           height={8}
-          accessibilityLabel={`${card.name} spending progress`}
+          accessible={false}
         />
 
         <View style={styles.metaRow} accessibilityElementsHidden>
@@ -341,39 +319,41 @@ export function CardTile({
               </Footnote>
             ) : null}
           </View>
-          <Footnote color={daysTone} style={styles.tabular} accessible={false}>
+          <Footnote color={daysTone} style={styles.tabular}>
             {daysLabel}
           </Footnote>
         </View>
 
         {blockCopy ? (
-          <Caption1 color="tertiary" style={styles.tabular} accessible={false}>
+          <Caption1 color="tertiary" style={styles.tabular} accessibilityElementsHidden>
             {blockCopy}
           </Caption1>
         ) : null}
+      </Pressable>
 
-        {card.subcategoriesEnabled && projection.rewardCategories.length > 0 ? (
+      {card.subcategoriesEnabled && projection.rewardCategories.length > 0 ? (
+        <View style={styles.footerSection}>
           <CardSubcategoryBreakdown
             categories={projection.rewardCategories}
             formatting={formatting}
             isExpanded={isSubcategoryExpanded}
             onToggleExpanded={onToggleSubcategories}
           />
-        ) : null}
+        </View>
+      ) : null}
 
-        {allowHideCard && exceeded ? (
-          <Pressable
-            onPress={() => onHideCard(card.id, period.end)}
-            accessibilityRole="button"
-            accessibilityLabel={`Hide ${card.name} until next cycle`}
-            style={({ pressed }) => [styles.hideButton, pressed && styles.pressed]}
-          >
-            <Caption1 color="secondary" style={styles.hideButtonText} accessible={false}>
-              Hide until next cycle
-            </Caption1>
-          </Pressable>
-        ) : null}
-      </Pressable>
+      {allowHideCard && exceeded ? (
+        <Pressable
+          onPress={() => onHideCard(card.id, period.end)}
+          accessibilityRole="button"
+          accessibilityLabel={`Hide ${card.name} until next cycle`}
+          style={({ pressed }) => [styles.hideButton, pressed && styles.pressed]}
+        >
+          <Caption1 color="secondary" style={styles.hideButtonText} accessible={false}>
+            Hide until next cycle
+          </Caption1>
+        </Pressable>
+      ) : null}
     </View>
   );
 }
@@ -387,6 +367,11 @@ const styles = StyleSheet.create({
   pressable: {
     padding: spacing.lg,
     gap: spacing.md,
+  },
+  footerSection: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+    marginTop: -spacing.sm,
   },
   pressed: {
     opacity: interaction.subtlePressedOpacity,
@@ -487,9 +472,9 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     minHeight: 36,
     justifyContent: 'center',
-    paddingHorizontal: spacing.sm,
-    marginTop: spacing.xs,
-    marginHorizontal: -spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    marginTop: -spacing.xs,
   },
   hideButtonText: {
     fontWeight: '600',

--- a/apps/mobile/src/features/overview/card-tile.tsx
+++ b/apps/mobile/src/features/overview/card-tile.tsx
@@ -348,7 +348,7 @@ export function CardTile({
 
       {allowHideCard && exceeded ? (
         <Pressable
-          onPress={() => onHideCard(card.id, projection.resetsOn)}
+          onPress={() => onHideCard(card.id, projection.period.end)}
           accessibilityRole="button"
           accessibilityLabel={`Hide ${card.name} until next cycle`}
           style={({ pressed }) => [styles.hideButton, pressed && styles.pressed]}

--- a/apps/mobile/src/features/overview/card-tile.tsx
+++ b/apps/mobile/src/features/overview/card-tile.tsx
@@ -1,0 +1,497 @@
+import React, { useMemo } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { SymbolView } from 'expo-symbols';
+
+import { Caption1, Footnote, Headline, Title3 } from '@/components/ios';
+import type { CardFormatting } from '@/features/cards/presentation';
+import { formatResetDate } from '@/features/cards/presentation';
+import { semanticColors, withAlpha } from '@/theme';
+import { interaction, radii, spacing } from '@/theme/tokens';
+import type { TextColor } from '@/components/ios/Typography';
+import type { CardDashboardProjection } from '@ynab-counter/app-core/rewards-engine';
+import type { CreditCard } from '@ynab-counter/app-core/storage';
+import { CardSubcategoryBreakdown } from './subcategory-breakdown';
+import { ZonesProgressBar } from './zones-progress-bar';
+
+const NEAR_CAP_RATIO = 0.8;
+
+type HeroVariant = 'cap-left' | 'cap-over' | 'min-left' | 'spent';
+
+interface HeroModel {
+  variant: HeroVariant;
+  amount: number;
+  tone: TextColor;
+  suffix: string;
+  label: string;
+  weight: 'semibold' | 'medium';
+}
+
+function cardUsesBlocks(card: CreditCard): boolean {
+  return Boolean(
+    (typeof card.earningBlockSize === 'number' && card.earningBlockSize > 0) ||
+      (card.subcategoriesEnabled &&
+        card.subcategories?.some(
+          (subcategory) =>
+            typeof subcategory.milesBlockSize === 'number' && subcategory.milesBlockSize > 0,
+        )),
+  );
+}
+
+export interface CardTileProps {
+  projection: CardDashboardProjection;
+  formatting: CardFormatting;
+  allowHideCard: boolean;
+  isSubcategoryExpanded: boolean;
+  onToggleSubcategories: () => void;
+  onHideCard: (cardId: string, hiddenUntil: string) => void;
+  onOpen: () => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * The web dashboard's card tile, adapted for a native touch target: reward
+ * chip, hero number ("X to go / left / over / spent"), zone-coloured progress
+ * bar, spend meta row, block copy, and an expandable category breakdown.
+ */
+export function CardTile({
+  projection,
+  formatting,
+  allowHideCard,
+  isSubcategoryExpanded,
+  onToggleSubcategories,
+  onHideCard,
+  onOpen,
+  style,
+}: CardTileProps) {
+  const { card, calculation, period } = projection;
+  const hasBlockRounding = cardUsesBlocks(card);
+  const displayedSpend = hasBlockRounding ? projection.spend.counted : projection.spend.total;
+  const hasMinimum = projection.minimum.target !== null;
+  const minimumTarget = projection.minimum.target ?? 0;
+  const hasMaximum = projection.maximum.target !== null;
+  const maximumTarget = projection.maximum.target ?? 0;
+  const minimumMet = projection.minimum.met !== false;
+  const exceeded = projection.maximum.reached;
+  const nearCap =
+    hasMaximum &&
+    !exceeded &&
+    maximumTarget > 0 &&
+    displayedSpend / maximumTarget >= NEAR_CAP_RATIO;
+
+  const remainingToMaximum = hasMaximum ? Math.max(0, maximumTarget - displayedSpend) : 0;
+  const exceededAmount = hasMaximum ? Math.max(0, displayedSpend - maximumTarget) : 0;
+  const remainingToMinimum = hasMinimum ? Math.max(0, minimumTarget - projection.spend.total) : 0;
+  const clampedProgress =
+    hasMinimum && minimumTarget > 0
+      ? Math.min(1, Math.max(0, projection.spend.total / minimumTarget))
+      : 0;
+  const progressPercent = Math.round(clampedProgress * 100);
+
+  const hero: HeroModel = useMemo(() => {
+    const variant: HeroVariant = hasMinimum && !minimumMet
+      ? 'min-left'
+      : hasMaximum && exceeded
+        ? 'cap-over'
+        : hasMaximum
+          ? 'cap-left'
+          : 'spent';
+    const capUrgent = variant === 'cap-left' && nearCap;
+    const tone: TextColor =
+      variant === 'cap-over'
+        ? 'destructive'
+        : variant === 'min-left' || capUrgent
+          ? 'attention'
+          : variant === 'cap-left' || (hasMinimum && minimumMet)
+            ? 'positive'
+            : 'primary';
+    const amount =
+      variant === 'cap-left'
+        ? remainingToMaximum
+        : variant === 'cap-over'
+          ? exceededAmount
+          : variant === 'min-left'
+            ? remainingToMinimum
+            : displayedSpend;
+    const suffix =
+      variant === 'min-left' ? 'to go'
+        : variant === 'cap-left' ? 'left'
+          : variant === 'cap-over' ? 'over'
+            : 'spent';
+    const label =
+      variant === 'cap-left'
+        ? `${remainingToMaximum.toFixed(2)} left before the cap`
+        : variant === 'cap-over'
+          ? `${exceededAmount.toFixed(2)} over the cap`
+          : variant === 'min-left'
+            ? `${remainingToMinimum.toFixed(2)} more to meet the minimum`
+            : `Spent ${displayedSpend.toFixed(2)} this period`;
+    return {
+      variant,
+      amount,
+      tone,
+      suffix,
+      label,
+      weight: variant === 'spent' || variant === 'cap-over' ? 'semibold' : 'medium',
+    };
+  }, [
+    displayedSpend,
+    exceeded,
+    exceededAmount,
+    hasMaximum,
+    hasMinimum,
+    minimumMet,
+    nearCap,
+    remainingToMaximum,
+    remainingToMinimum,
+  ]);
+
+  const earnedNumber = projection.reward.amount;
+  const earnedDisplay = Math.round(earnedNumber).toLocaleString();
+  const rewardChipTone: TextColor = exceeded
+    ? 'destructive'
+    : hasMinimum && !minimumMet
+      ? 'attention'
+      : card.type === 'cashback'
+        ? 'positive'
+        : 'action';
+  const rewardChipColor = {
+    destructive: semanticColors.capped,
+    attention: semanticColors.attention,
+    positive: semanticColors.positive,
+    action: semanticColors.systemBlue,
+  }[rewardChipTone];
+
+  const heroLabel: string =
+    hero.variant === 'cap-left' || hero.variant === 'cap-over'
+      ? `${formatting.currencyRounded(maximumTarget)} cap`
+      : hero.variant === 'min-left'
+        ? `${formatting.currencyRounded(minimumTarget)} min`
+        : 'This period';
+
+  const daysRemaining = projection.daysRemaining;
+  const daysTone: TextColor = daysRemaining <= 1
+    ? 'destructive'
+    : daysRemaining <= 3
+      ? 'attention'
+      : daysRemaining <= 7
+        ? 'attention'
+        : 'tertiary';
+  const daysLabel = `${daysRemaining}d`;
+
+  const blockCount = projection.blockInfo?.blocksEarned ?? null;
+  const blockSize = projection.blockInfo?.sizes[0] ?? null;
+  const showBlocks = Boolean(
+    blockSize &&
+      blockSize > 0 &&
+      (blockCount !== null ? blockCount > 0 : (projection.blockInfo?.eligibleSpendBeforeBlocks ?? 0) > 0),
+  );
+  const blockCopy = showBlocks && blockSize && blockSize > 0
+    ? `${blockCount !== null
+        ? blockCount
+        : Math.floor((projection.blockInfo?.eligibleSpendBeforeBlocks ?? 0) / blockSize)} × ${formatting.currencyRounded(blockSize)} blocks`
+    : undefined;
+
+  const heroNumberText =
+    hero.variant === 'cap-left' || hero.variant === 'cap-over' || hero.variant === 'min-left'
+      ? formatting.currencyRounded(hero.amount)
+      : formatting.currencyCompact(hero.amount);
+
+  const spendMeta = hero.variant === 'spent'
+    ? undefined
+    : `Spent ${formatting.currencyRounded(displayedSpend)}`;
+  const minimumMeta = hasMinimum && hero.variant !== 'min-left'
+    ? minimumMet
+      ? `Met ${formatting.currencyRounded(minimumTarget)} min`
+      : `${progressPercent}% of ${formatting.currencyRounded(minimumTarget)} min`
+    : undefined;
+  const noLimitsMeta = !hasMinimum && !hasMaximum;
+
+  const borderTone = exceeded
+    ? { borderColor: semanticColors.capped, borderWidth: 1.5 }
+    : nearCap
+      ? { borderColor: semanticColors.attention, borderWidth: 1.5 }
+      : { borderColor: semanticColors.separator, borderWidth: StyleSheet.hairlineWidth };
+
+  return (
+    <View style={[styles.tile, borderTone, style]} accessibilityElementsHidden>
+      <Pressable
+        onPress={onOpen}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={`${card.name}, ${earnedDisplay} ${card.type === 'cashback' ? 'cashback' : 'miles'} earned, ${hero.label}${blockCopy ? `, ${blockCopy}` : ''}`}
+        accessibilityHint="Opens card details"
+        style={({ pressed }) => [styles.pressable, pressed && styles.pressed]}
+      >
+        <View style={styles.header}>
+          <Headline numberOfLines={1} style={styles.cardName}>{card.name}</Headline>
+          <View style={styles.headerTrailing}>
+            {card.promotionalPeriod ? (
+              <View style={styles.promoPill} accessible accessibilityLabel={`Promotional period until ${formatResetDate(card.promotionalPeriod.endDate)}`}>
+                <SymbolView
+                  name="sparkles"
+                  size={11}
+                  tintColor={semanticColors.systemPurple}
+                  accessibilityElementsHidden
+                />
+                <Caption1 color="action" style={styles.promoText} accessible={false}>Promo</Caption1>
+              </View>
+            ) : null}
+            <View
+              accessible
+              accessibilityRole="text"
+              accessibilityLabel={
+                card.type === 'cashback'
+                  ? `Earned ${earnedDisplay} cashback`
+                  : `Earned ${earnedDisplay} miles`
+              }
+              style={styles.rewardChip}
+            >
+              <SymbolView
+                name={card.type === 'cashback' ? 'dollarsign.circle.fill' : 'airplane'}
+                size={14}
+                tintColor={rewardChipColor}
+                style={styles.rewardIcon}
+                accessibilityElementsHidden
+              />
+              <Footnote color={rewardChipTone} style={styles.rewardChipText} accessible={false}>
+                {earnedDisplay}
+              </Footnote>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.heroRow}>
+          <Caption1 color="secondary" style={styles.heroLabel} accessible={false}>
+            {heroLabel}
+          </Caption1>
+          <View
+            accessible
+            accessibilityRole="text"
+            accessibilityLabel={hero.label}
+            style={styles.heroValueRow}
+          >
+            {hero.variant === 'min-left' ? (
+              <SymbolView
+                name="arrow.up.right"
+                size={13}
+                tintColor={semanticColors.attention}
+                style={styles.heroGlyph}
+                accessibilityElementsHidden
+              />
+            ) : hero.variant === 'cap-left' ? (
+              <SymbolView
+                name="gauge"
+                size={13}
+                tintColor={semanticColors.positive}
+                style={styles.heroGlyph}
+                accessibilityElementsHidden
+              />
+            ) : hero.variant === 'cap-over' ? (
+              <SymbolView
+                name="exclamationmark.octagon"
+                size={13}
+                tintColor={semanticColors.destructive}
+                style={styles.heroGlyph}
+                accessibilityElementsHidden
+              />
+            ) : null}
+            <Title3
+              color={hero.tone}
+              style={[styles.heroNumber, hero.weight === 'medium' && styles.heroNumberMedium]}
+              accessible={false}
+            >
+              {heroNumberText}
+            </Title3>
+            <Caption1
+              color={hero.variant === 'spent' ? 'secondary' : hero.tone}
+              style={styles.heroSuffix}
+              accessible={false}
+            >
+              {hero.suffix}
+            </Caption1>
+          </View>
+        </View>
+
+        <ZonesProgressBar
+          totalSpend={projection.spend.total}
+          minimumSpend={hasMinimum ? projection.minimum.target : null}
+          maximumSpend={hasMaximum ? projection.maximum.target : null}
+          minimumProgressSpend={projection.progress.minimumProgressSpend}
+          maximumProgressSpend={projection.progress.maximumProgressSpend}
+          height={8}
+          accessibilityLabel={`${card.name} spending progress`}
+        />
+
+        <View style={styles.metaRow} accessibilityElementsHidden>
+          <View style={styles.metaCopy}>
+            {spendMeta || minimumMeta || noLimitsMeta ? (
+              <Footnote color="secondary" numberOfLines={2}>
+                {spendMeta ? <Footnote color="secondary">{spendMeta}</Footnote> : null}
+                {spendMeta && minimumMeta ? <Footnote color="tertiary"> · </Footnote> : null}
+                {minimumMeta ? (
+                  <Footnote color={minimumMet ? 'positive' : 'attention'}>{minimumMeta}</Footnote>
+                ) : null}
+                {noLimitsMeta ? <Footnote color="secondary" style={styles.italic}>No spend limits</Footnote> : null}
+              </Footnote>
+            ) : null}
+          </View>
+          <Footnote color={daysTone} style={styles.tabular} accessible={false}>
+            {daysLabel}
+          </Footnote>
+        </View>
+
+        {blockCopy ? (
+          <Caption1 color="tertiary" style={styles.tabular} accessible={false}>
+            {blockCopy}
+          </Caption1>
+        ) : null}
+
+        {card.subcategoriesEnabled && projection.rewardCategories.length > 0 ? (
+          <CardSubcategoryBreakdown
+            categories={projection.rewardCategories}
+            formatting={formatting}
+            isExpanded={isSubcategoryExpanded}
+            onToggleExpanded={onToggleSubcategories}
+          />
+        ) : null}
+
+        {allowHideCard && exceeded ? (
+          <Pressable
+            onPress={() => onHideCard(card.id, period.end)}
+            accessibilityRole="button"
+            accessibilityLabel={`Hide ${card.name} until next cycle`}
+            style={({ pressed }) => [styles.hideButton, pressed && styles.pressed]}
+          >
+            <Caption1 color="secondary" style={styles.hideButtonText} accessible={false}>
+              Hide until next cycle
+            </Caption1>
+          </Pressable>
+        ) : null}
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  tile: {
+    borderRadius: radii.xlarge,
+    backgroundColor: semanticColors.secondarySystemGroupedBackground,
+    overflow: 'hidden',
+  },
+  pressable: {
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  pressed: {
+    opacity: interaction.subtlePressedOpacity,
+  },
+  header: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  cardName: {
+    flex: 1,
+    minWidth: 120,
+  },
+  headerTrailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    flexShrink: 0,
+  },
+  promoPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radii.pill,
+    backgroundColor: withAlpha('#AF52DE', '1F'),
+  },
+  promoText: {
+    color: semanticColors.systemPurple,
+    fontWeight: '600',
+  },
+  rewardChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xxs,
+  },
+  rewardIcon: {
+    flexShrink: 0,
+  },
+  rewardChipText: {
+    fontWeight: '600',
+  },
+  heroRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    columnGap: spacing.md,
+    rowGap: spacing.xs,
+  },
+  heroLabel: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    fontWeight: '600',
+  },
+  heroValueRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xxs,
+  },
+  heroGlyph: {
+    alignSelf: 'center',
+    marginRight: spacing.xxs,
+  },
+  heroNumber: {
+    fontSize: 24,
+    lineHeight: 28,
+    letterSpacing: -0.5,
+    fontVariant: ['tabular-nums'],
+  },
+  heroNumberMedium: {
+    fontWeight: '500',
+  },
+  heroSuffix: {
+    fontWeight: '600',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: spacing.md,
+    rowGap: spacing.xs,
+  },
+  metaCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+  tabular: {
+    fontVariant: ['tabular-nums'],
+  },
+  hideButton: {
+    alignSelf: 'flex-start',
+    minHeight: 36,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
+    marginTop: spacing.xs,
+    marginHorizontal: -spacing.sm,
+  },
+  hideButtonText: {
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/features/overview/index.ts
+++ b/apps/mobile/src/features/overview/index.ts
@@ -1,0 +1,15 @@
+export { CardGroupHeader } from './card-group';
+export { CardTile, type CardTileProps } from './card-tile';
+export {
+  setDashboardPeriodValue,
+  useDashboardPeriod,
+  getDashboardPeriodValue,
+  todayDateValue,
+} from './period-store';
+export {
+  StatusSummary,
+  type HiddenCardEntry,
+  type StatusSummaryProps,
+} from './status-summary';
+export { CardSubcategoryBreakdown } from './subcategory-breakdown';
+export { ZonesProgressBar, type ZonesProgressBarProps } from './zones-progress-bar';

--- a/apps/mobile/src/features/overview/period-store.ts
+++ b/apps/mobile/src/features/overview/period-store.ts
@@ -1,5 +1,9 @@
-import { useSyncExternalStore } from 'react';
-import { formatDateValue, resolveDashboardPeriod } from '@/lib/dashboard-period';
+import { useMemo, useSyncExternalStore } from 'react';
+import {
+  formatDateValue,
+  resolveDashboardPeriod,
+  type DashboardPeriodSelection,
+} from '@/lib/dashboard-period';
 
 /**
  * Session-scoped dashboard period. The web app keeps this in the URL; on
@@ -33,9 +37,15 @@ function subscribe(listener: () => void): () => void {
   };
 }
 
-export function useDashboardPeriod(now = new Date()) {
+export function useDashboardPeriod(now?: Date): DashboardPeriodSelection {
   const dateValue = useSyncExternalStore(subscribe, getDashboardPeriodValue, getDashboardPeriodValue);
-  return resolveDashboardPeriod(dateValue, now);
+  // Stabilize on the calendar day so historical Overview does not rebuild the
+  // rewards dashboard on every render from a fresh `new Date()` identity.
+  const todayKey = formatDateValue(now ?? new Date());
+  return useMemo(
+    () => resolveDashboardPeriod(dateValue, now ?? new Date()),
+    [dateValue, now, todayKey],
+  );
 }
 
 export function todayDateValue(now = new Date()): string {

--- a/apps/mobile/src/features/overview/period-store.ts
+++ b/apps/mobile/src/features/overview/period-store.ts
@@ -1,0 +1,43 @@
+import { useSyncExternalStore } from 'react';
+import { formatDateValue, resolveDashboardPeriod } from '@/lib/dashboard-period';
+
+/**
+ * Session-scoped dashboard period. The web app keeps this in the URL; on
+ * mobile a tiny external store keeps the overview and its period sheet in
+ * sync without polluting storage or cloud-sync payloads.
+ */
+let currentDateValue: string | undefined;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((listener) => listener());
+}
+
+export function getDashboardPeriodValue(): string | undefined {
+  return currentDateValue;
+}
+
+export function setDashboardPeriodValue(dateValue: string | undefined) {
+  const next = dateValue ?? undefined;
+  if (next === currentDateValue) {
+    return;
+  }
+  currentDateValue = next;
+  emit();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useDashboardPeriod(now = new Date()) {
+  const dateValue = useSyncExternalStore(subscribe, getDashboardPeriodValue, getDashboardPeriodValue);
+  return resolveDashboardPeriod(dateValue, now);
+}
+
+export function todayDateValue(now = new Date()): string {
+  return formatDateValue(now);
+}

--- a/apps/mobile/src/features/overview/status-summary.tsx
+++ b/apps/mobile/src/features/overview/status-summary.tsx
@@ -16,14 +16,7 @@ export interface HiddenCardEntry {
 
 type SlotColor = 'sky' | 'green' | 'amber' | 'red';
 
-const DOT_COLORS = {
-  sky: semanticColors.systemBlue,
-  green: semanticColors.positive,
-  amber: semanticColors.attention,
-  red: semanticColors.capped,
-} as const;
-
-const ACTIVE_TEXT_COLORS = {
+const SLOT_COLORS = {
   sky: semanticColors.systemBlue,
   green: semanticColors.positive,
   amber: semanticColors.attention,
@@ -34,8 +27,7 @@ type SummarySlot = {
   key: 'below-minimum' | 'earning' | 'near-cap' | 'at-cap';
   statuses: CardPortfolioStatus[];
   describe: (count: number) => string;
-  dotColor: SlotColor;
-  activeTextColor: SlotColor;
+  color: SlotColor;
 };
 
 const STATUS_SLOTS: SummarySlot[] = [
@@ -43,29 +35,25 @@ const STATUS_SLOTS: SummarySlot[] = [
     key: 'below-minimum',
     statuses: ['building'],
     describe: (count) => `${count} below minimum spend`,
-    dotColor: 'sky',
-    activeTextColor: 'sky',
+    color: 'sky',
   },
   {
     key: 'earning',
     statuses: ['earning', 'open'],
     describe: (count) => `${count} earning rewards`,
-    dotColor: 'green',
-    activeTextColor: 'green',
+    color: 'green',
   },
   {
     key: 'near-cap',
     statuses: ['near_cap'],
     describe: (count) => `${count} near cap`,
-    dotColor: 'amber',
-    activeTextColor: 'amber',
+    color: 'amber',
   },
   {
     key: 'at-cap',
     statuses: ['capped'],
     describe: (count) => `${count} at cap`,
-    dotColor: 'red',
-    activeTextColor: 'red',
+    color: 'red',
   },
 ];
 
@@ -130,14 +118,14 @@ export function StatusSummary({
                   <View
                     style={[
                       styles.dot,
-                      { backgroundColor: DOT_COLORS[slot.dotColor] },
+                      { backgroundColor: SLOT_COLORS[slot.color] },
                       count === 0 && styles.dotDimmed,
                     ]}
                   />
                   <Footnote
                     color={count === 0 ? 'tertiary' : 'primary'}
                     style={[
-                      count > 0 && { color: ACTIVE_TEXT_COLORS[slot.activeTextColor] },
+                      count > 0 && { color: SLOT_COLORS[slot.color] },
                       styles.tabular,
                     ]}
                   >

--- a/apps/mobile/src/features/overview/status-summary.tsx
+++ b/apps/mobile/src/features/overview/status-summary.tsx
@@ -1,0 +1,305 @@
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { SymbolView } from 'expo-symbols';
+
+import { Caption1, Footnote } from '@/components/ios';
+import type { CardFormatting } from '@/features/cards/presentation';
+import { semanticColors } from '@/theme';
+import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
+import type { CardDashboardProjection, CardPortfolioStatus } from '@ynab-counter/app-core/rewards-engine';
+
+export interface HiddenCardEntry {
+  cardId: string;
+  name: string;
+  hiddenUntil: string;
+}
+
+type SlotColor = 'sky' | 'green' | 'amber' | 'red';
+
+const DOT_COLORS = {
+  sky: semanticColors.systemBlue,
+  green: semanticColors.positive,
+  amber: semanticColors.attention,
+  red: semanticColors.capped,
+} as const;
+
+const ACTIVE_TEXT_COLORS = {
+  sky: semanticColors.systemBlue,
+  green: semanticColors.positive,
+  amber: semanticColors.attention,
+  red: semanticColors.capped,
+} as const;
+
+type SummarySlot = {
+  key: 'below-minimum' | 'earning' | 'near-cap' | 'at-cap';
+  statuses: CardPortfolioStatus[];
+  describe: (count: number) => string;
+  dotColor: SlotColor;
+  activeTextColor: SlotColor;
+};
+
+const STATUS_SLOTS: SummarySlot[] = [
+  {
+    key: 'below-minimum',
+    statuses: ['building'],
+    describe: (count) => `${count} below minimum spend`,
+    dotColor: 'sky',
+    activeTextColor: 'sky',
+  },
+  {
+    key: 'earning',
+    statuses: ['earning', 'open'],
+    describe: (count) => `${count} earning rewards`,
+    dotColor: 'green',
+    activeTextColor: 'green',
+  },
+  {
+    key: 'near-cap',
+    statuses: ['near_cap'],
+    describe: (count) => `${count} near cap`,
+    dotColor: 'amber',
+    activeTextColor: 'amber',
+  },
+  {
+    key: 'at-cap',
+    statuses: ['capped'],
+    describe: (count) => `${count} at cap`,
+    dotColor: 'red',
+    activeTextColor: 'red',
+  },
+];
+
+export interface StatusSummaryProps {
+  projections: CardDashboardProjection[];
+  earnedDollars: number;
+  formatting: CardFormatting;
+  hiddenCards?: HiddenCardEntry[];
+  onUnhideCard?: (cardId: string) => void;
+  onUnhideAll?: () => void;
+}
+
+/**
+ * The web dashboard's lifecycle strip: four dot/count clusters (below minimum,
+ * earning, near cap, at cap), the approximate value earned this period, and
+ * expandable chips for cards hidden until their next cycle.
+ */
+export function StatusSummary({
+  projections,
+  earnedDollars,
+  formatting,
+  hiddenCards = [],
+  onUnhideCard,
+  onUnhideAll,
+}: StatusSummaryProps) {
+  const [hiddenOpen, setHiddenOpen] = useState(false);
+
+  const counts = projections.reduce((acc, projection) => {
+    const slot = STATUS_SLOTS.find((candidate) => candidate.statuses.includes(projection.status));
+    if (slot) {
+      acc[slot.key] += 1;
+    }
+    return acc;
+  }, {
+    'below-minimum': 0,
+    earning: 0,
+    'near-cap': 0,
+    'at-cap': 0,
+  });
+
+  const showHidden = hiddenCards.length > 0 && Boolean(onUnhideCard);
+  const earnedLabel = `≈ ${formatting.currencyRounded(earnedDollars)} earned this period`;
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={styles.strip}
+        accessible
+        accessibilityRole="summary"
+        accessibilityLabel={[
+          STATUS_SLOTS.map((slot) => slot.describe(counts[slot.key])).join(', '),
+          earnedLabel,
+        ].join('. ')}
+      >
+        <View style={styles.dotsRow} accessibilityElementsHidden>
+          {STATUS_SLOTS.map((slot, index) => {
+            const count = counts[slot.key];
+            return (
+              <React.Fragment key={slot.key}>
+                {index > 0 ? <Footnote color="tertiary">/</Footnote> : null}
+                <View style={styles.dotSlot}>
+                  <View
+                    style={[
+                      styles.dot,
+                      { backgroundColor: DOT_COLORS[slot.dotColor] },
+                      count === 0 && styles.dotDimmed,
+                    ]}
+                  />
+                  <Footnote
+                    color={count === 0 ? 'tertiary' : 'primary'}
+                    style={[
+                      count > 0 && { color: ACTIVE_TEXT_COLORS[slot.activeTextColor] },
+                      styles.tabular,
+                    ]}
+                  >
+                    {count}
+                  </Footnote>
+                </View>
+              </React.Fragment>
+            );
+          })}
+        </View>
+
+        {showHidden ? (
+          <Pressable
+            onPress={() => setHiddenOpen((open) => !open)}
+            accessibilityRole="button"
+            accessibilityLabel={`${hiddenCards.length} hidden ${hiddenCards.length === 1 ? 'card' : 'cards'}`}
+            accessibilityHint={hiddenOpen ? 'Collapses hidden cards' : 'Shows hidden cards'}
+            accessibilityState={{ expanded: hiddenOpen }}
+            style={({ pressed }) => [styles.hiddenButton, pressed && styles.pressed]}
+          >
+            <SymbolView
+              name="eye.slash"
+              size={11}
+              tintColor={semanticColors.secondaryLabel}
+              accessibilityElementsHidden
+            />
+            <Caption1 color="secondary" style={styles.hiddenLabel}>{hiddenCards.length} hidden</Caption1>
+            <SymbolView
+              name="chevron.down"
+              size={9}
+              tintColor={semanticColors.tertiaryLabel}
+              style={hiddenOpen && styles.chevronOpen}
+              accessibilityElementsHidden
+            />
+          </Pressable>
+        ) : null}
+
+        <Footnote color="tertiary" style={[styles.earned, styles.tabular]} accessible={false}>
+          {earnedLabel}
+        </Footnote>
+      </View>
+
+      {showHidden && hiddenOpen ? (
+        <View style={styles.hiddenPanel}>
+          <Caption1 color="secondary" accessible={false}>
+            Hidden until next cycle:
+          </Caption1>
+          <View style={styles.chips}>
+            {hiddenCards.map((entry) => (
+              <Pressable
+                key={entry.cardId}
+                onPress={() => onUnhideCard?.(entry.cardId)}
+                accessibilityRole="button"
+                accessibilityLabel={`Show ${entry.name} again`}
+                style={({ pressed }) => [styles.chip, pressed && styles.pressed]}
+              >
+                <Caption1 color="secondary" numberOfLines={1} style={styles.chipName} accessible={false}>
+                  {entry.name}
+                </Caption1>
+                <SymbolView
+                  name="xmark"
+                  size={9}
+                  tintColor={semanticColors.tertiaryLabel}
+                  accessibilityElementsHidden
+                />
+              </Pressable>
+            ))}
+          </View>
+          {hiddenCards.length > 1 && onUnhideAll ? (
+            <Pressable
+              onPress={onUnhideAll}
+              accessibilityRole="button"
+              accessibilityLabel="Show all hidden cards"
+              style={({ pressed }) => [styles.showAll, pressed && styles.pressed]}
+            >
+              <Caption1 color="action" accessible={false}>Show all</Caption1>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  strip: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    columnGap: spacing.md,
+    rowGap: spacing.xs,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing.sm,
+  },
+  dotSlot: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  dot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+  },
+  dotDimmed: {
+    opacity: 0.35,
+  },
+  hiddenButton: {
+    minHeight: nativeMetrics.minimumTouchTarget,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginVertical: -spacing.sm,
+  },
+  hiddenLabel: {
+    fontWeight: '600',
+  },
+  chevronOpen: {
+    transform: [{ rotate: '180deg' }],
+  },
+  earned: {
+    marginLeft: 'auto',
+  },
+  tabular: {
+    fontVariant: ['tabular-nums'],
+  },
+  hiddenPanel: {
+    gap: spacing.sm,
+    paddingTop: spacing.sm,
+  },
+  chips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  chip: {
+    maxWidth: 220,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.tertiarySystemFill,
+  },
+  chipName: {
+    flexShrink: 1,
+  },
+  showAll: {
+    alignSelf: 'flex-start',
+    minHeight: nativeMetrics.minimumTouchTarget,
+    justifyContent: 'center',
+    marginHorizontal: -spacing.sm,
+    paddingHorizontal: spacing.sm,
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+});

--- a/apps/mobile/src/features/overview/status-summary.tsx
+++ b/apps/mobile/src/features/overview/status-summary.tsx
@@ -111,22 +111,22 @@ export function StatusSummary({
 
   return (
     <View style={styles.container}>
-      <View
-        style={styles.strip}
-        accessible
-        accessibilityRole="summary"
-        accessibilityLabel={[
-          STATUS_SLOTS.map((slot) => slot.describe(counts[slot.key])).join(', '),
-          earnedLabel,
-        ].join('. ')}
-      >
-        <View style={styles.dotsRow} accessibilityElementsHidden>
+      <View style={styles.strip}>
+        <View
+          style={styles.dotsRow}
+          accessible
+          accessibilityRole="summary"
+          accessibilityLabel={[
+            STATUS_SLOTS.map((slot) => slot.describe(counts[slot.key])).join(', '),
+            earnedLabel,
+          ].join('. ')}
+        >
           {STATUS_SLOTS.map((slot, index) => {
             const count = counts[slot.key];
             return (
               <React.Fragment key={slot.key}>
-                {index > 0 ? <Footnote color="tertiary">/</Footnote> : null}
-                <View style={styles.dotSlot}>
+                {index > 0 ? <Footnote color="tertiary" accessible={false}>/</Footnote> : null}
+                <View style={styles.dotSlot} accessibilityElementsHidden>
                   <View
                     style={[
                       styles.dot,
@@ -164,7 +164,9 @@ export function StatusSummary({
               tintColor={semanticColors.secondaryLabel}
               accessibilityElementsHidden
             />
-            <Caption1 color="secondary" style={styles.hiddenLabel}>{hiddenCards.length} hidden</Caption1>
+            <Caption1 color="secondary" style={styles.hiddenLabel} accessible={false}>
+              {hiddenCards.length} hidden
+            </Caption1>
             <SymbolView
               name="chevron.down"
               size={9}

--- a/apps/mobile/src/features/overview/subcategory-breakdown.tsx
+++ b/apps/mobile/src/features/overview/subcategory-breakdown.tsx
@@ -1,0 +1,258 @@
+import React, { useMemo } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  View,
+  type ColorValue,
+} from 'react-native';
+import { SymbolView } from 'expo-symbols';
+
+import { Caption1, Footnote, Headline } from '@/components/ios';
+import type { CardFormatting } from '@/features/cards/presentation';
+import { flagColor } from '@/features/cards/presentation';
+import { semanticColors } from '@/theme';
+import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
+import type { TextColor } from '@/components/ios/Typography';
+import type { RewardCategoryProjection } from '@ynab-counter/app-core/rewards-engine';
+
+const NEAR_CAP_RATIO = 0.8;
+const MIN_SEGMENT_RATIO = 0.025;
+
+interface Segment {
+  key: string;
+  color: ColorValue;
+  spend: number;
+}
+
+function segmentsFor(categories: RewardCategoryProjection[]): Segment[] {
+  const total = categories.reduce((sum, category) => sum + category.spend.total, 0);
+  if (total <= 0) {
+    return [];
+  }
+  return categories
+    .filter((category) => category.spend.total / total >= MIN_SEGMENT_RATIO)
+    .sort((left, right) => right.spend.total - left.spend.total)
+    .map((category) => ({
+      key: category.id,
+      color: flagColor(category.flagColor),
+      spend: category.spend.total,
+    }));
+}
+
+function capPercentage(
+  category: RewardCategoryProjection,
+): number | null {
+  if (category.maximum.target === null || category.maximum.target <= 0) {
+    return null;
+  }
+  const percent = ((category.spend.total / category.maximum.target) * 100);
+  return Math.round(percent);
+}
+
+function capPercentTone(percent: number): TextColor {
+  if (percent >= 90) {
+    return 'destructive';
+  }
+  if (percent >= 75) {
+    return 'attention';
+  }
+  return 'secondary';
+}
+
+function capPercentLabel(category: RewardCategoryProjection, formatting: CardFormatting): string | undefined {
+  const percent = capPercentage(category);
+  const target = category.maximum.target;
+  if (percent === null || target === null || target <= 0) {
+    return undefined;
+  }
+  const spent = formatting.currencyCompact(category.spend.total);
+  const cap = formatting.currencyCompact(target);
+  const tone = capPercentTone(percent);
+  return `${spent} of ${cap} · ${percent}%`;
+}
+
+export interface CardSubcategoryBreakdownProps {
+  categories: RewardCategoryProjection[];
+  formatting: CardFormatting;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
+}
+
+/**
+ * Per-card composition: a flag-coloured stacked bar plus expandable rows with
+ * spend against each tier's cap. Mirrors the web summary compact breakdown.
+ */
+export function CardSubcategoryBreakdown({
+  categories,
+  formatting,
+  isExpanded,
+  onToggleExpanded,
+}: CardSubcategoryBreakdownProps) {
+  const segments = useMemo(() => segmentsFor(categories), [categories]);
+  const totalSpend = useMemo(
+    () => categories.reduce((sum, category) => sum + category.spend.total, 0),
+    [categories],
+  );
+  const rows = useMemo(
+    () => [...categories].sort((left, right) => right.spend.total - left.spend.total),
+    [categories],
+  );
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        onPress={onToggleExpanded}
+        accessibilityRole="button"
+        accessibilityLabel={`Reward categories, ${totalSpend > 0 ? `${rows
+          .filter((category) => category.spend.total > 0)
+          .map((category) => `${category.name}, ${formatting.currencyCompact(category.spend.total)}`)
+          .join(', ')}` : 'no spend this period'}`}
+        accessibilityHint={isExpanded ? 'Collapses reward category detail' : 'Expands reward category detail'}
+        accessibilityState={{ expanded: isExpanded }}
+        style={({ pressed }) => [styles.header, pressed && styles.pressed]}
+      >
+        <Caption1 color="secondary" style={styles.eyebrow} accessible={false}>
+          Categories
+        </Caption1>
+        <SymbolView
+          name="chevron.down"
+          size={10}
+          tintColor={semanticColors.tertiaryLabel}
+          style={[styles.chevron, isExpanded && styles.chevronExpanded]}
+          accessibilityElementsHidden
+        />
+      </Pressable>
+
+      {segments.length > 0 ? (
+        <View
+          style={styles.bar}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          {segments.map((segment) => (
+            <View
+              key={segment.key}
+              style={[
+                styles.segment,
+                { backgroundColor: segment.color, flexGrow: segment.spend },
+              ]}
+            />
+          ))}
+        </View>
+      ) : null}
+
+      {isExpanded ? (
+        <View style={styles.rows}>
+          {rows.map((category, index) => {
+            const percent = capPercentage(category);
+            const percentLabel = capPercentLabel(category, formatting);
+            return (
+              <View
+                key={category.id}
+                style={[styles.row, index < rows.length - 1 && styles.rowDivider]}
+                accessible
+                accessibilityLabel={`${category.name}, ${formatting.currencyCompact(category.spend.total)} spent${percentLabel ? `, ${percentLabel}` : ''}`}
+              >
+                <View style={styles.rowIdentity} accessibilityElementsHidden>
+                  <View style={[styles.flagDot, { backgroundColor: flagColor(category.flagColor) }]} />
+                  <Headline style={styles.rowName} numberOfLines={1}>{category.name}</Headline>
+                </View>
+                <View style={styles.rowTrailing} accessibilityElementsHidden>
+                  {percent !== null ? (
+                    <Footnote color={capPercentTone(percent)} style={styles.tabular}>
+                      {percentLabel}
+                    </Footnote>
+                  ) : (
+                    <Footnote color="secondary" style={styles.tabular}>
+                      {formatting.currencyCompact(category.spend.total)}
+                    </Footnote>
+                  )}
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  header: {
+    minHeight: 32,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  eyebrow: {
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    fontWeight: '600',
+  },
+  chevron: {},
+  chevronExpanded: {
+    transform: [{ rotate: '180deg' }],
+  },
+  bar: {
+    height: 11,
+    flexDirection: 'row',
+    gap: 2,
+    overflow: 'hidden',
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.progressTrack,
+  },
+  segment: {
+    flexBasis: 0,
+    minWidth: 2,
+    height: 11,
+  },
+  rows: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: semanticColors.separator,
+    paddingTop: spacing.sm,
+    gap: spacing.sm,
+  },
+  row: {
+    minHeight: 24,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+    paddingVertical: spacing.xxs,
+  },
+  rowDivider: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: semanticColors.separator,
+    paddingBottom: spacing.sm,
+  },
+  rowIdentity: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  flagDot: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+    flexShrink: 0,
+  },
+  rowName: {
+    flex: 1,
+    minWidth: 0,
+  },
+  rowTrailing: {
+    flexShrink: 0,
+  },
+  tabular: {
+    fontVariant: ['tabular-nums'],
+  },
+  pressed: {
+    opacity: interaction.pressedOpacity,
+  },
+});

--- a/apps/mobile/src/features/overview/subcategory-breakdown.tsx
+++ b/apps/mobile/src/features/overview/subcategory-breakdown.tsx
@@ -66,7 +66,6 @@ function capPercentLabel(category: RewardCategoryProjection, formatting: CardFor
   }
   const spent = formatting.currencyCompact(category.spend.total);
   const cap = formatting.currencyCompact(target);
-  const tone = capPercentTone(percent);
   return `${spent} of ${cap} · ${percent}%`;
 }
 

--- a/apps/mobile/src/features/overview/subcategory-breakdown.tsx
+++ b/apps/mobile/src/features/overview/subcategory-breakdown.tsx
@@ -11,11 +11,10 @@ import { Caption1, Footnote, Headline } from '@/components/ios';
 import type { CardFormatting } from '@/features/cards/presentation';
 import { flagColor } from '@/features/cards/presentation';
 import { semanticColors } from '@/theme';
-import { interaction, nativeMetrics, radii, spacing } from '@/theme/tokens';
+import { interaction, radii, spacing } from '@/theme/tokens';
 import type { TextColor } from '@/components/ios/Typography';
 import type { RewardCategoryProjection } from '@ynab-counter/app-core/rewards-engine';
 
-const NEAR_CAP_RATIO = 0.8;
 const MIN_SEGMENT_RATIO = 0.025;
 
 interface Segment {

--- a/apps/mobile/src/features/overview/zones-progress-bar.tsx
+++ b/apps/mobile/src/features/overview/zones-progress-bar.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { semanticColors } from '@/theme';
+import { nativeMetrics, radii } from '@/theme/tokens';
+
+const NEAR_CAP_RATIO = 0.8;
+
+type SpendingZone = 'neutral' | 'pending' | 'earning' | 'nearing' | 'exceeded';
+
+function finitePositive(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function spendingZone(params: {
+  hasMinimum: boolean;
+  hasMaximum: boolean;
+  minimumMet: boolean;
+  maximumExceeded: boolean;
+  nearingMaximum: boolean;
+}): SpendingZone {
+  if (!params.hasMinimum && !params.hasMaximum) {
+    return 'neutral';
+  }
+  if (params.maximumExceeded) {
+    return 'exceeded';
+  }
+  if (params.minimumMet && params.nearingMaximum) {
+    return 'nearing';
+  }
+  if (params.minimumMet) {
+    return 'earning';
+  }
+  return 'pending';
+}
+
+function zoneFillColor(zone: SpendingZone) {
+  switch (zone) {
+    case 'exceeded':
+      return semanticColors.capped;
+    case 'nearing':
+      return semanticColors.attention;
+    case 'earning':
+      return semanticColors.positive;
+    case 'pending':
+      return semanticColors.systemYellow;
+    case 'neutral':
+      return semanticColors.action;
+  }
+}
+
+export interface ZonesProgressBarProps {
+  totalSpend: number;
+  minimumSpend?: number | null;
+  maximumSpend?: number | null;
+  minimumProgressSpend?: number;
+  maximumProgressSpend?: number;
+  height?: number;
+  accessible?: boolean;
+  accessibilityLabel?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * The web dashboard's zone-aware spend bar: yellow while climbing to the
+ * minimum, green while earning, orange nearing the cap, red past it, with
+ * threshold markers at the minimum (grey) and cap (red).
+ */
+export function ZonesProgressBar({
+  totalSpend,
+  minimumSpend,
+  maximumSpend,
+  minimumProgressSpend,
+  maximumProgressSpend,
+  height = nativeMetrics.railHeight,
+  accessible = true,
+  accessibilityLabel,
+  style,
+}: ZonesProgressBarProps) {
+  const hasMinimum = finitePositive(minimumSpend);
+  const hasMaximum = finitePositive(maximumSpend);
+  const hasLimits = hasMinimum || hasMaximum;
+  const spendForMinimum = minimumProgressSpend ?? totalSpend;
+  const spendForMaximum = maximumProgressSpend ?? totalSpend;
+
+  const minimumMet = !hasMinimum || spendForMinimum >= minimumSpend;
+  const maximumExceeded = hasMaximum && spendForMaximum >= maximumSpend;
+  const nearingMaximum = hasMaximum && spendForMaximum >= maximumSpend * NEAR_CAP_RATIO;
+  const zone = spendingZone({ hasMinimum, hasMaximum, minimumMet, maximumExceeded, nearingMaximum });
+
+  const progressPercent = hasMaximum
+    ? Math.min(100, (spendForMaximum / maximumSpend) * 100)
+    : hasMinimum
+      ? Math.min(100, (spendForMinimum / minimumSpend) * 100)
+      : 0;
+  const roundedPercent = Math.round(progressPercent);
+  const zeroProgress = hasLimits && progressPercent === 0;
+  const markerHeight = height + 6;
+  const minimumPosition = hasMinimum && hasMaximum
+    ? Math.min(100, (minimumSpend / maximumSpend) * 100)
+    : hasMinimum
+      ? 100
+      : undefined;
+  const maximumPosition = hasMaximum ? 100 : undefined;
+
+  const stateText =
+    zone === 'exceeded'
+      ? maximumExceeded && spendForMaximum > maximumSpend
+        ? `Spending cap exceeded by ${spendForMaximum - maximumSpend}`
+        : 'Spending cap reached'
+      : zone === 'nearing'
+        ? `Nearing cap: ${roundedPercent}% of cap used`
+        : zone === 'earning'
+          ? hasMaximum
+            ? `Earning rewards: ${roundedPercent}% of cap used`
+            : `Earning rewards: ${roundedPercent}%`
+          : zone === 'pending'
+            ? `Working towards minimum: ${roundedPercent}%`
+            : `Spending progress: ${roundedPercent}%`;
+
+  return (
+    <View
+      style={style}
+      accessible={accessible}
+      accessibilityRole={accessible && hasLimits ? 'progressbar' : undefined}
+      accessibilityLabel={accessible ? (accessibilityLabel ?? 'Spend progress') : undefined}
+      accessibilityValue={
+        accessible && hasLimits
+          ? {
+              min: 0,
+              max: 100,
+              now: roundedPercent,
+              text: stateText,
+            }
+          : undefined
+      }
+    >
+      <View style={[styles.track, { height }]}>
+        {hasLimits && progressPercent > 0 ? (
+          <View
+            style={[
+              styles.fill,
+              {
+                height,
+                width: `${progressPercent}%`,
+                backgroundColor: zoneFillColor(zone),
+              },
+              zeroProgress && styles.zeroFill,
+            ]}
+          />
+        ) : hasLimits ? (
+          <View style={[styles.zeroFill, { height: 3 }]} />
+        ) : null}
+
+        {hasMinimum && minimumPosition !== undefined && minimumPosition > 0 && minimumPosition < 100 ? (
+          <View
+            style={[
+              styles.minimumMarker,
+              { left: `${minimumPosition}%`, height: markerHeight },
+              minimumMet && styles.minimumMetMarker,
+            ]}
+          />
+        ) : null}
+
+        {hasMaximum ? (
+          <View style={[styles.capMarker, { height: markerHeight }, maximumExceeded && styles.capReachedMarker]} />
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    position: 'relative',
+    width: '100%',
+    overflow: 'hidden',
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.progressTrack,
+  },
+  fill: {
+    maxWidth: '100%',
+    borderRadius: radii.pill,
+  },
+  zeroFill: {
+    borderRadius: radii.pill,
+    backgroundColor: semanticColors.action,
+  },
+  minimumMarker: {
+    position: 'absolute',
+    top: -3,
+    width: 2,
+    marginLeft: -1,
+    borderRadius: 1,
+    backgroundColor: semanticColors.secondaryLabel,
+  },
+  minimumMetMarker: {
+    backgroundColor: semanticColors.positive,
+  },
+  capMarker: {
+    position: 'absolute',
+    top: -2,
+    right: -1,
+    width: 2,
+    borderRadius: 1,
+    backgroundColor: semanticColors.capped,
+  },
+  capReachedMarker: {
+    opacity: 1,
+  },
+});

--- a/apps/mobile/src/features/overview/zones-progress-bar.tsx
+++ b/apps/mobile/src/features/overview/zones-progress-bar.tsx
@@ -55,6 +55,7 @@ export interface ZonesProgressBarProps {
   minimumProgressSpend?: number;
   maximumProgressSpend?: number;
   height?: number;
+  formatAmount?: (value: number) => string;
   accessible?: boolean;
   accessibilityLabel?: string;
   style?: StyleProp<ViewStyle>;
@@ -72,6 +73,7 @@ export function ZonesProgressBar({
   minimumProgressSpend,
   maximumProgressSpend,
   height = nativeMetrics.railHeight,
+  formatAmount,
   accessible = true,
   accessibilityLabel,
   style,
@@ -93,19 +95,21 @@ export function ZonesProgressBar({
       ? Math.min(100, (spendForMinimum / minimumSpend) * 100)
       : 0;
   const roundedPercent = Math.round(progressPercent);
-  const zeroProgress = hasLimits && progressPercent === 0;
   const markerHeight = height + 6;
   const minimumPosition = hasMinimum && hasMaximum
     ? Math.min(100, (minimumSpend / maximumSpend) * 100)
     : hasMinimum
       ? 100
       : undefined;
-  const maximumPosition = hasMaximum ? 100 : undefined;
+  const overflowAmount = hasMaximum ? Math.max(0, spendForMaximum - maximumSpend) : 0;
+  const overflowLabel = formatAmount
+    ? formatAmount(overflowAmount)
+    : String(overflowAmount);
 
   const stateText =
     zone === 'exceeded'
-      ? maximumExceeded && spendForMaximum > maximumSpend
-        ? `Spending cap exceeded by ${spendForMaximum - maximumSpend}`
+      ? maximumExceeded && overflowAmount > 0
+        ? `Spending cap exceeded by ${overflowLabel}`
         : 'Spending cap reached'
       : zone === 'nearing'
         ? `Nearing cap: ${roundedPercent}% of cap used`
@@ -144,7 +148,6 @@ export function ZonesProgressBar({
                 width: `${progressPercent}%`,
                 backgroundColor: zoneFillColor(zone),
               },
-              zeroProgress && styles.zeroFill,
             ]}
           />
         ) : hasLimits ? (
@@ -205,6 +208,7 @@ const styles = StyleSheet.create({
     backgroundColor: semanticColors.capped,
   },
   capReachedMarker: {
-    opacity: 1,
+    width: 3,
+    right: -1.5,
   },
 });

--- a/apps/mobile/src/lib/dashboard-period.test.ts
+++ b/apps/mobile/src/lib/dashboard-period.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDateValue,
+  parseDateValue,
+  resolveDashboardPeriod,
+  shiftDashboardPeriodDays,
+  shiftDashboardPeriodMonths,
+} from './dashboard-period';
+
+const NOW = new Date(2026, 7, 14, 13, 30, 0);
+
+describe('parseDateValue', () => {
+  it('parses a valid YYYY-MM-DD value', () => {
+    expect(formatDateValue(parseDateValue('2026-08-14')!)).toBe('2026-08-14');
+  });
+
+  it('rejects invalid formats', () => {
+    expect(parseDateValue('2026-8-14')).toBeNull();
+    expect(parseDateValue('14/08/2026')).toBeNull();
+    expect(parseDateValue('2026-02-30')).toBeNull();
+    expect(parseDateValue('')).toBeNull();
+    expect(parseDateValue(undefined)).toBeNull();
+  });
+});
+
+describe('resolveDashboardPeriod', () => {
+  it('defaults to today when no date is supplied', () => {
+    const period = resolveDashboardPeriod(undefined, NOW);
+    expect(period.isToday).toBe(true);
+    expect(period.dateValue).toBe('2026-08-14');
+    expect(period.triggerLabel).toBe('Today');
+    expect(period.asOfLabel).toContain('Aug');
+    expect(period.asOfLabel).toContain('2026');
+  });
+
+  it('resolves a past date and bounds rewards to that day', () => {
+    const period = resolveDashboardPeriod('2026-08-05', NOW);
+    expect(period.isToday).toBe(false);
+    expect(period.isCurrentMonth).toBe(true);
+    expect(period.dateValue).toBe('2026-08-05');
+    expect(period.triggerLabel).toContain('Aug');
+    expect(period.referenceDate.getHours()).toBe(0);
+  });
+
+  it('clamps future dates to today', () => {
+    const period = resolveDashboardPeriod('2026-09-20', NOW);
+    expect(period.isToday).toBe(true);
+    expect(period.dateValue).toBe('2026-08-14');
+  });
+});
+
+describe('shiftDashboardPeriodDays', () => {
+  it('steps forward and backward by whole days', () => {
+    expect(shiftDashboardPeriodDays('2026-08-13', 1, NOW)).toBe('2026-08-14');
+    expect(shiftDashboardPeriodDays('2026-08-14', -1, NOW)).toBe('2026-08-13');
+  });
+
+  it('never advances past today', () => {
+    expect(shiftDashboardPeriodDays('2026-08-14', 5, NOW)).toBe('2026-08-14');
+  });
+});
+
+describe('shiftDashboardPeriodMonths', () => {
+  it('steps between months preserving the day of month', () => {
+    expect(shiftDashboardPeriodMonths('2026-08-05', -1, NOW)).toBe('2026-07-05');
+    expect(shiftDashboardPeriodMonths('2026-06-20', 1, NOW)).toBe('2026-07-20');
+    expect(shiftDashboardPeriodMonths('2026-08-05', 1, NOW)).toBe('2026-08-14');
+  });
+
+  it('clamps the day when the target month is shorter', () => {
+    expect(shiftDashboardPeriodMonths('2026-05-31', -1, NOW)).toBe('2026-04-30');
+  });
+});

--- a/apps/mobile/src/lib/dashboard-period.ts
+++ b/apps/mobile/src/lib/dashboard-period.ts
@@ -2,10 +2,6 @@ function truncateDate(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-function endOfMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
-}
-
 function isSameDay(left: Date, right: Date): boolean {
   return (
     left.getFullYear() === right.getFullYear() &&
@@ -16,22 +12,6 @@ function isSameDay(left: Date, right: Date): boolean {
 
 function isSameMonth(left: Date, right: Date): boolean {
   return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
-}
-
-function parseMonthValue(value: string | null | undefined): Date | null {
-  if (!value || !/^\d{4}-\d{2}$/.test(value)) {
-    return null;
-  }
-
-  const [yearRaw, monthRaw] = value.split('-');
-  const year = Number(yearRaw);
-  const monthIndex = Number(monthRaw) - 1;
-
-  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || monthIndex < 0 || monthIndex > 11) {
-    return null;
-  }
-
-  return new Date(year, monthIndex, 1);
 }
 
 export function parseDateValue(value: string | null | undefined): Date | null {

--- a/apps/mobile/src/lib/dashboard-period.ts
+++ b/apps/mobile/src/lib/dashboard-period.ts
@@ -1,0 +1,151 @@
+function truncateDate(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function endOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function isSameDay(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+function isSameMonth(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
+}
+
+function parseMonthValue(value: string | null | undefined): Date | null {
+  if (!value || !/^\d{4}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearRaw, monthRaw] = value.split('-');
+  const year = Number(yearRaw);
+  const monthIndex = Number(monthRaw) - 1;
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || monthIndex < 0 || monthIndex > 11) {
+    return null;
+  }
+
+  return new Date(year, monthIndex, 1);
+}
+
+export function parseDateValue(value: string | null | undefined): Date | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearRaw, monthRaw, dayRaw] = value.split('-');
+  const year = Number(yearRaw);
+  const monthIndex = Number(monthRaw) - 1;
+  const day = Number(dayRaw);
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  const parsed = new Date(year, monthIndex, day);
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== monthIndex ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function formatMonthValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+export function formatDateValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function clampToToday(date: Date, today: Date): Date {
+  return date > today ? today : date;
+}
+
+export interface DashboardPeriodSelection {
+  dateValue: string;
+  monthValue: string;
+  referenceDate: Date;
+  isToday: boolean;
+  isCurrentMonth: boolean;
+  monthLabel: string;
+  asOfLabel: string;
+  triggerLabel: string;
+}
+
+export function resolveDashboardPeriod(
+  asOfValue: string | null | undefined,
+  now: Date = new Date(),
+): DashboardPeriodSelection {
+  const today = truncateDate(now);
+  const parsedAsOf = parseDateValue(asOfValue);
+  const requestedDate = parsedAsOf ?? today;
+  const safeDate = clampToToday(requestedDate, today);
+  const isToday = isSameDay(safeDate, today);
+  const referenceDate = isToday ? now : safeDate;
+
+  return {
+    dateValue: formatDateValue(safeDate),
+    monthValue: formatMonthValue(safeDate),
+    referenceDate,
+    isToday,
+    isCurrentMonth: isSameMonth(safeDate, today),
+    monthLabel: safeDate.toLocaleDateString(undefined, {
+      month: 'long',
+      year: 'numeric',
+    }),
+    asOfLabel: safeDate.toLocaleDateString(undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    }),
+    triggerLabel: isToday
+      ? 'Today'
+      : safeDate.toLocaleDateString(undefined, {
+          day: 'numeric',
+          month: 'short',
+        }),
+  };
+}
+
+export function shiftDashboardPeriodDays(
+  dateValue: string,
+  deltaDays: number,
+  now: Date = new Date(),
+): string {
+  const today = truncateDate(now);
+  const baseDate = parseDateValue(dateValue) ?? today;
+  const shifted = new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate() + deltaDays);
+  return formatDateValue(clampToToday(shifted, today));
+}
+
+export function shiftDashboardPeriodMonths(
+  dateValue: string,
+  deltaMonths: number,
+  now: Date = new Date(),
+): string {
+  const today = truncateDate(now);
+  const baseDate = parseDateValue(dateValue) ?? today;
+  const targetYear = baseDate.getFullYear();
+  const targetMonth = baseDate.getMonth() + deltaMonths;
+  const lastDayOfTargetMonth = new Date(targetYear, targetMonth + 1, 0).getDate();
+  const targetDay = Math.min(baseDate.getDate(), lastDayOfTargetMonth);
+  const shifted = new Date(targetYear, targetMonth, targetDay);
+
+  return formatDateValue(clampToToday(shifted, today));
+}

--- a/apps/mobile/src/storage/service.test.ts
+++ b/apps/mobile/src/storage/service.test.ts
@@ -812,3 +812,44 @@ describe('settings import dirty-marker preconditions', () => {
     }
   });
 });
+
+describe('replaceCards cascade', () => {
+  it('returns pruned hiddenCards so React state can stay in sync', async () => {
+    const initial = createDefaultStorage();
+    initial.cards = [{
+      id: 'keep-card',
+      name: 'Keep',
+      issuer: 'Test',
+      type: 'cashback',
+      featured: true,
+      earningRate: 1,
+      ynabAccountId: 'account-keep',
+    }, {
+      id: 'drop-card',
+      name: 'Drop',
+      issuer: 'Test',
+      type: 'cashback',
+      featured: true,
+      earningRate: 1,
+      ynabAccountId: 'account-drop',
+    }];
+    initial.hiddenCards = [{
+      cardId: 'keep-card',
+      hiddenUntil: '2099-08-01T00:00:00.000Z',
+      reason: 'maximum_spend_reached',
+    }, {
+      cardId: 'drop-card',
+      hiddenUntil: '2099-08-01T00:00:00.000Z',
+      reason: 'maximum_spend_reached',
+    }];
+    mocks.asyncValues.set(STORAGE_VERSION_KEY, STORAGE_VERSION);
+    mocks.asyncValues.set(STORAGE_KEY, JSON.stringify(initial));
+
+    const service = new StorageService();
+    await service.getSettings();
+    const replacement = await service.replaceCards([initial.cards[0]!]);
+
+    expect(replacement.hiddenCards?.map((entry) => entry.cardId)).toEqual(['keep-card']);
+    expect((await service.getHiddenCards()).map((entry) => entry.cardId)).toEqual(['keep-card']);
+  });
+});

--- a/apps/mobile/src/storage/service.ts
+++ b/apps/mobile/src/storage/service.ts
@@ -550,7 +550,7 @@ export class StorageService {
   async replaceCards(
     cards: readonly CreditCard[],
     expectedGeneration = this.operationGeneration,
-  ): Promise<Pick<StorageData, 'cards' | 'rules' | 'tagMappings' | 'calculations' | 'themeGroups'>> {
+  ): Promise<Pick<StorageData, 'cards' | 'rules' | 'tagMappings' | 'calculations' | 'themeGroups' | 'hiddenCards'>> {
     return this.updateStorageAtomically(expectedGeneration, (storage) => {
       const flagNames = storage.cachedData?.flagNames;
       const nextCards = cards.map((card) =>
@@ -571,6 +571,7 @@ export class StorageService {
         tagMappings: [...storage.tagMappings],
         calculations: [...storage.calculations],
         themeGroups: [...storage.themeGroups],
+        hiddenCards: [...(storage.hiddenCards ?? [])],
       };
     });
   }

--- a/packages/app-core/src/utils/currency.test.ts
+++ b/packages/app-core/src/utils/currency.test.ts
@@ -92,7 +92,10 @@ describe('formatCurrencyParts', () => {
   });
 
   it('falls back to a single formatted segment when formatToParts is unavailable', () => {
-    const original = Intl.NumberFormat.prototype.formatToParts;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Intl.NumberFormat.prototype,
+      'formatToParts',
+    );
     Object.defineProperty(Intl.NumberFormat.prototype, 'formatToParts', {
       configurable: true,
       value: undefined,
@@ -100,12 +103,13 @@ describe('formatCurrencyParts', () => {
     try {
       const parts = formatCurrencyParts(123.45, { locale: 'en-US', currency: 'USD' });
       expect(parts).toEqual([{ type: 'literal', value: expect.any(String) }]);
-      expect(formatCurrency(123.45, { locale: 'en-US', currency: 'USD' })).toMatch(/\$?123/);
+      expect(formatCurrency(123.45, { locale: 'en-US', currency: 'USD' })).toBe('$123.45');
     } finally {
-      Object.defineProperty(Intl.NumberFormat.prototype, 'formatToParts', {
-        configurable: true,
-        value: original,
-      });
+      if (originalDescriptor) {
+        Object.defineProperty(Intl.NumberFormat.prototype, 'formatToParts', originalDescriptor);
+      } else {
+        Reflect.deleteProperty(Intl.NumberFormat.prototype, 'formatToParts');
+      }
     }
   });
 

--- a/packages/app-core/src/utils/currency.test.ts
+++ b/packages/app-core/src/utils/currency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  applyCurrencySymbolOverride,
   createCurrencyFormatter,
   formatCurrency,
   formatCurrencyParts,
@@ -98,7 +99,7 @@ describe('formatCurrencyParts', () => {
     });
     try {
       const parts = formatCurrencyParts(123.45, { locale: 'en-US', currency: 'USD' });
-      expect(parts).toEqual([{ type: 'decimal', value: expect.any(String) }]);
+      expect(parts).toEqual([{ type: 'literal', value: expect.any(String) }]);
       expect(formatCurrency(123.45, { locale: 'en-US', currency: 'USD' })).toMatch(/\$?123/);
     } finally {
       Object.defineProperty(Intl.NumberFormat.prototype, 'formatToParts', {
@@ -106,6 +107,18 @@ describe('formatCurrencyParts', () => {
         value: original,
       });
     }
+  });
+
+});
+
+describe('applyCurrencySymbolOverride', () => {
+  it('normalises US$ and USD tokens to $ for USD', () => {
+    expect(applyCurrencySymbolOverride('US$123.45', 'USD')).toBe('$123.45');
+    expect(applyCurrencySymbolOverride('123,45 USD', 'USD')).toBe('123,45 $');
+  });
+
+  it('leaves non-USD currencies untouched', () => {
+    expect(applyCurrencySymbolOverride('€123.45', 'EUR')).toBe('€123.45');
   });
 });
 

--- a/packages/app-core/src/utils/currency.test.ts
+++ b/packages/app-core/src/utils/currency.test.ts
@@ -89,6 +89,24 @@ describe('formatCurrencyParts', () => {
     // The leading part stays numeric, so substitution did not reorder anything.
     expect(parts[0]?.type).toBe('integer');
   });
+
+  it('falls back to a single formatted segment when formatToParts is unavailable', () => {
+    const original = Intl.NumberFormat.prototype.formatToParts;
+    Object.defineProperty(Intl.NumberFormat.prototype, 'formatToParts', {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      const parts = formatCurrencyParts(123.45, { locale: 'en-US', currency: 'USD' });
+      expect(parts).toEqual([{ type: 'decimal', value: expect.any(String) }]);
+      expect(formatCurrency(123.45, { locale: 'en-US', currency: 'USD' })).toMatch(/\$?123/);
+    } finally {
+      Object.defineProperty(Intl.NumberFormat.prototype, 'formatToParts', {
+        configurable: true,
+        value: original,
+      });
+    }
+  });
 });
 
 describe('normalizeCurrencyCode', () => {

--- a/packages/app-core/src/utils/currency.ts
+++ b/packages/app-core/src/utils/currency.ts
@@ -22,6 +22,20 @@ const currencySymbolOverrides: Record<string, string> = {
 };
 
 /**
+ * Apply platform symbol overrides to a fully formatted currency string.
+ * Used when `formatToParts` is unavailable (some Hermes Intl builds).
+ */
+export function applyCurrencySymbolOverride(formatted: string, currency: string): string {
+  const replacement = currencySymbolOverrides[currency.toUpperCase()];
+  if (!replacement) {
+    return formatted;
+  }
+  return formatted
+    .replace(/\bUS\$/gu, replacement)
+    .replace(/\bUSD\b/gu, replacement);
+}
+
+/**
  * Create an Intl.NumberFormat instance for currency formatting.
  * Requires explicit locale and currency - use platform-specific
  * resolution for defaults (navigator.language, user settings, etc.).
@@ -64,10 +78,14 @@ export function formatCurrencyParts(
   const formatter = createCurrencyFormatter(options);
   const replacement = currencySymbolOverrides[options.currency.toUpperCase()];
 
-  // Some Hermes Intl builds omit `formatToParts`; fall back to a single
-  // formatted segment so currency rendering never crashes on-device.
+  // Some Hermes Intl builds omit `formatToParts`; fall back to a formatted
+  // segment so currency rendering never crashes on-device. Still apply the
+  // USD symbol override so locales that emit `US$` stay consistent with web.
   if (typeof formatter.formatToParts !== 'function') {
-    return [{ type: 'decimal', value: formatter.format(value) }];
+    return [{
+      type: 'literal',
+      value: applyCurrencySymbolOverride(formatter.format(value), options.currency),
+    }];
   }
 
   const parts = formatter.formatToParts(value);

--- a/packages/app-core/src/utils/currency.ts
+++ b/packages/app-core/src/utils/currency.ts
@@ -61,8 +61,16 @@ export function formatCurrencyParts(
   value: number,
   options: CurrencyFormatterOptions,
 ): Intl.NumberFormatPart[] {
-  const parts = createCurrencyFormatter(options).formatToParts(value);
+  const formatter = createCurrencyFormatter(options);
   const replacement = currencySymbolOverrides[options.currency.toUpperCase()];
+
+  // Some Hermes Intl builds omit `formatToParts`; fall back to a single
+  // formatted segment so currency rendering never crashes on-device.
+  if (typeof formatter.formatToParts !== 'function') {
+    return [{ type: 'decimal', value: formatter.format(value) }];
+  }
+
+  const parts = formatter.formatToParts(value);
 
   if (!replacement) {
     return parts;


### PR DESCRIPTION
Brings the iOS app's look, feel and feature set in line with the web app on mobile.

**Dashboard (Overview tab)**
- Ported the web dashboard: period navigation (day/month steppers, jump-to-date, live vs historical snapshots), status summary strip, card tiles with hero numbers and zone-coloured progress bars, promo and reward chips, expandable flag-colour category breakdowns, hide-until-next-cycle, collapsible cashback/miles groups, and an all-hidden empty state.
- Quick-stats tiles removed from the top per feedback (settings stays in the tab bar).

**Feature parity**
- Per-card transactions screen (`card/[id]/transactions`) with a view-all action on card detail.
- Activity account filter chips (web's account filter).
- Promo and flag-rule badges on card rows (web's All Cards view).
- Orphaned-card cleanup under Data & privacy.

**Bug fix**
- `fix(app-core)`: Hermes Intl omits `formatToParts` on some iOS releases, which crashed every currency render; added a `format()` fallback.

Verified on an iOS 27 simulator with demo data (all screens OCR-checked); mobile typecheck, mobile tests (82) and app-core tests (130) pass.