### PR TITLE
Refine iOS tab-root hierarchy

### DIFF
--- a/apps/mobile/app/(tabs)/activity/[id].tsx
+++ b/apps/mobile/app/(tabs)/activity/[id].tsx
@@ -11,7 +11,6 @@ import { SparkIcon } from '@/components/brand';
 import {
   Body,
   Card,
-  Caption1,
   Footnote,
   Headline,
   LargeTitle,
@@ -351,7 +350,6 @@ export default function TransactionDetailScreen() {
         automaticallyAdjustsScrollIndicatorInsets
       >
         <View style={styles.hero}>
-          <Caption1 color="secondary">Transaction</Caption1>
           <Title1 accessibilityRole="header">{payee}</Title1>
           <LargeTitle
             style={projection.status === 'incoming' ? styles.incoming : undefined}

--- a/apps/mobile/app/(tabs)/activity/_layout.tsx
+++ b/apps/mobile/app/(tabs)/activity/_layout.tsx
@@ -1,10 +1,7 @@
 import { Stack } from 'expo-router';
 import { Platform, useColorScheme } from 'react-native';
 
-import {
-  nativeStackScreenOptions,
-  usesIOS26LargeTitleFallback,
-} from '@/theme';
+import { nativeStackScreenOptions } from '@/theme';
 
 export default function ActivityLayout() {
   const systemScheme = useColorScheme();
@@ -16,8 +13,7 @@ export default function ActivityLayout() {
         name="index"
         options={{
           title: 'Activity',
-          headerLargeTitle: !usesIOS26LargeTitleFallback,
-          headerShown: !usesIOS26LargeTitleFallback,
+          headerShown: false,
         }}
       />
       <Stack.Screen

--- a/apps/mobile/app/(tabs)/activity/index.tsx
+++ b/apps/mobile/app/(tabs)/activity/index.tsx
@@ -12,11 +12,7 @@ import {
 import { useRouter } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
 
-import {
-  EmptyState,
-  LargeNavigationTitle,
-  SyncBadge,
-} from '@/components/native';
+import { EmptyState, SyncBadge } from '@/components/native';
 import { Footnote, Headline } from '@/components/ios';
 import { useStorage } from '@/contexts/StorageContext';
 import {
@@ -189,7 +185,6 @@ export default function ActivityScreen() {
         renderSectionFooter={() => <View style={styles.sectionFooter} />}
         ListHeaderComponent={(
           <View style={styles.topMatter}>
-            <LargeNavigationTitle>Activity</LargeNavigationTitle>
             <View style={styles.search}>
               <SymbolView
                 name="magnifyingglass"

--- a/apps/mobile/app/(tabs)/cards/_layout.tsx
+++ b/apps/mobile/app/(tabs)/cards/_layout.tsx
@@ -1,10 +1,7 @@
 import { Stack } from 'expo-router';
 import { Platform, useColorScheme } from 'react-native';
 
-import {
-  nativeStackScreenOptions,
-  usesIOS26LargeTitleFallback,
-} from '@/theme';
+import { nativeStackScreenOptions } from '@/theme';
 
 export default function CardsLayout() {
   const systemScheme = useColorScheme();
@@ -16,8 +13,7 @@ export default function CardsLayout() {
         name="index"
         options={{
           title: 'Cards',
-          headerLargeTitle: !usesIOS26LargeTitleFallback,
-          headerShown: !usesIOS26LargeTitleFallback,
+          headerShown: false,
         }}
       />
     </Stack>

--- a/apps/mobile/app/(tabs)/cards/index.tsx
+++ b/apps/mobile/app/(tabs)/cards/index.tsx
@@ -15,7 +15,6 @@ import { useStorage } from '@/contexts/StorageContext';
 import {
   CardStatusRow,
   EmptyState,
-  LargeNavigationTitle,
   SectionTitle,
   SyncBadge,
 } from '@/components/native';
@@ -132,7 +131,6 @@ export default function CardsScreen() {
         />
       )}
     >
-      <LargeNavigationTitle>Cards</LargeNavigationTitle>
       <View style={styles.topMatter}>
         <View style={styles.search}>
           <SymbolView

--- a/apps/mobile/app/(tabs)/overview/_layout.tsx
+++ b/apps/mobile/app/(tabs)/overview/_layout.tsx
@@ -16,8 +16,7 @@ export default function OverviewLayout() {
         name="index"
         options={{
           title: 'Overview',
-          headerLargeTitle: !usesIOS26LargeTitleFallback,
-          headerShown: !usesIOS26LargeTitleFallback,
+          headerShown: false,
         }}
       />
       <Stack.Screen

--- a/apps/mobile/app/(tabs)/overview/index.tsx
+++ b/apps/mobile/app/(tabs)/overview/index.tsx
@@ -10,8 +10,8 @@ import { useRouter } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
 
 import { useStorage } from '@/contexts/StorageContext';
-import { EmptyState, LargeNavigationTitle, SectionTitle } from '@/components/native';
-import { Body, Footnote, Headline } from '@/components/ios';
+import { EmptyState, SectionTitle } from '@/components/native';
+import { Footnote, Headline } from '@/components/ios';
 import {
   createCardFormatting,
   flagColor,
@@ -117,7 +117,28 @@ function cardUseOperationalLabel(
   return undefined;
 }
 
-function CardUseRow({
+function compactCardUseDetail(
+  item: RankedCardUse,
+  formatting: CardFormatting,
+): string {
+  if (item.operational?.kind === 'minimum') {
+    return `${thresholdCurrency(item.operational.remaining, formatting)} to unlock`;
+  }
+
+  const rate = formatting.number(item.rate.value);
+  const rateLabel = item.rate.type === 'cashback'
+    ? `${rate}%`
+    : `${rate} mi/${formatting.currency}1`;
+  const blockLabel = item.rate.blockSize === null
+    ? ''
+    : ` · ${thresholdCurrency(item.rate.blockSize, formatting)} blocks`;
+  const roomLabel = item.operational?.kind === 'cap'
+    ? ` · ${thresholdCurrency(item.operational.remaining, formatting)} left`
+    : '';
+  return `${rateLabel}${blockLabel}${roomLabel}`;
+}
+
+function CardUseColumn({
   item,
   formatting,
   onPress,
@@ -130,6 +151,7 @@ function CardUseRow({
 }) {
   const rateLabel = cardUseRateLabel(item, formatting);
   const operationalLabel = cardUseOperationalLabel(item, formatting);
+  const compactDetail = compactCardUseDetail(item, formatting);
 
   return (
     <Pressable
@@ -145,8 +167,8 @@ function CardUseRow({
         ? `Opens the ${item.use.label} earning tier on ${item.card.card.name}`
         : `Opens details for ${item.card.card.name}`}
       style={({ pressed }) => [
-        styles.cardUseRow,
-        showDivider && styles.rowDivider,
+        styles.cardUseColumn,
+        showDivider && styles.columnDivider,
         pressed && styles.pressed,
       ]}
     >
@@ -155,7 +177,7 @@ function CardUseRow({
         accessibilityElementsHidden
         importantForAccessibility="no-hide-descendants"
       >
-        <Headline>{compactCardName(item.card.card.name)}</Headline>
+        <Headline numberOfLines={1}>{compactCardName(item.card.card.name)}</Headline>
         <View style={styles.useLabelRow}>
           {item.use.flagColor ? (
             <SymbolView
@@ -165,13 +187,11 @@ function CardUseRow({
               style={styles.flagIcon}
             />
           ) : null}
-          <Body style={styles.flexibleText}>{item.use.label} · {rateLabel}</Body>
-        </View>
-        {operationalLabel ? (
-          <Footnote color="secondary" style={styles.tabular}>
-            {operationalLabel}
+          <Footnote color="secondary" numberOfLines={1} style={styles.flexibleText}>
+            {item.use.label}
           </Footnote>
-        ) : null}
+        </View>
+        <Footnote numberOfLines={1} style={styles.tabular}>{compactDetail}</Footnote>
       </View>
     </Pressable>
   );
@@ -410,6 +430,7 @@ export default function OverviewScreen() {
     () => rankCardUses(nonCappedCards, state.settings),
     [nonCappedCards, state.settings],
   );
+  const cardUsePreview = useMemo(() => cardUses.slice(0, 3), [cardUses]);
   const rewardCategories = useMemo(
     () => collectRewardCategories(nonCappedCards),
     [nonCappedCards],
@@ -545,30 +566,25 @@ export default function OverviewScreen() {
         />
       )}
     >
-      <View style={styles.top}>
-        <LargeNavigationTitle style={styles.navigationTitle}>
-          Overview
-        </LargeNavigationTitle>
-        <View style={styles.topRow}>
-          {periodTrigger}
-          {connected && state.cards.length > 0 &&
-          (model.syncState === 'offline' || model.syncState === 'attention') ? (
-            <Pressable
-              onPress={model.canSync ? model.refresh : () => router.push('/settings')}
-              accessibilityRole="button"
-              accessibilityLabel={syncActionLabel}
-              accessibilityHint={model.canSync
-                ? 'Retries syncing rewards from YNAB'
-                : 'Opens YNAB connection settings'}
-              style={({ pressed }) => [
-                styles.syncAction,
-                pressed && styles.pressed,
-              ]}
-            >
-              <Footnote color="action">{syncActionLabel}</Footnote>
-            </Pressable>
-          ) : null}
-        </View>
+      <View style={styles.topRow}>
+        {periodTrigger}
+        {connected && state.cards.length > 0 &&
+        (model.syncState === 'offline' || model.syncState === 'attention') ? (
+          <Pressable
+            onPress={model.canSync ? model.refresh : () => router.push('/settings')}
+            accessibilityRole="button"
+            accessibilityLabel={syncActionLabel}
+            accessibilityHint={model.canSync
+              ? 'Retries syncing rewards from YNAB'
+              : 'Opens YNAB connection settings'}
+            style={({ pressed }) => [
+              styles.syncAction,
+              pressed && styles.pressed,
+            ]}
+          >
+            <Footnote color="action">{syncActionLabel}</Footnote>
+          </Pressable>
+        ) : null}
       </View>
 
       {!connected ? (
@@ -623,17 +639,17 @@ export default function OverviewScreen() {
             />
           ) : null}
 
-          {cardUses.length > 0 ? (
+          {cardUsePreview.length > 0 ? (
             <View style={styles.section}>
               <SectionTitle title="Keep using" />
-              <View style={styles.rows}>
-                {cardUses.map((item, index) => (
-                  <CardUseRow
+              <View style={styles.cardUseColumns}>
+                {cardUsePreview.map((item, index) => (
+                  <CardUseColumn
                     key={item.key}
                     item={item}
                     formatting={formatting}
                     onPress={() => openCardUse(item)}
-                    showDivider={index < cardUses.length - 1}
+                    showDivider={index > 0}
                   />
                 ))}
               </View>
@@ -742,12 +758,6 @@ const styles = StyleSheet.create({
     paddingBottom: 120,
     gap: spacing.xxl,
   },
-  top: {
-    gap: spacing.sm,
-  },
-  navigationTitle: {
-    marginTop: spacing.sm,
-  },
   topRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -784,10 +794,25 @@ const styles = StyleSheet.create({
     backgroundColor: semanticColors.secondarySystemGroupedBackground,
     overflow: 'hidden',
   },
-  cardUseRow: {
+  cardUseColumns: {
+    minHeight: 88,
+    flexDirection: 'row',
+    marginHorizontal: -spacing.md,
+    borderRadius: radii.large,
+    backgroundColor: semanticColors.secondarySystemGroupedBackground,
+    overflow: 'hidden',
+  },
+  cardUseColumn: {
+    flex: 1,
+    minWidth: 0,
     minHeight: nativeMetrics.minimumTouchTarget,
-    paddingHorizontal: spacing.lg,
+    justifyContent: 'center',
+    paddingHorizontal: spacing.sm,
     paddingVertical: spacing.md,
+  },
+  columnDivider: {
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderLeftColor: semanticColors.separator,
   },
   setupRow: {
     minHeight: nativeMetrics.minimumTouchTarget,

--- a/apps/mobile/app/(tabs)/preferences/_layout.tsx
+++ b/apps/mobile/app/(tabs)/preferences/_layout.tsx
@@ -1,10 +1,7 @@
 import { Stack } from 'expo-router';
 import { Platform, useColorScheme } from 'react-native';
 
-import {
-  nativeStackScreenOptions,
-  usesIOS26LargeTitleFallback,
-} from '@/theme';
+import { nativeStackScreenOptions } from '@/theme';
 
 export default function PreferencesLayout() {
   const systemScheme = useColorScheme();
@@ -16,8 +13,7 @@ export default function PreferencesLayout() {
         name="index"
         options={{
           title: 'Settings',
-          headerLargeTitle: !usesIOS26LargeTitleFallback,
-          headerShown: !usesIOS26LargeTitleFallback,
+          headerShown: false,
         }}
       />
       <Stack.Screen

--- a/apps/mobile/app/(tabs)/preferences/index.tsx
+++ b/apps/mobile/app/(tabs)/preferences/index.tsx
@@ -3,10 +3,7 @@ import { Linking, ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 
 import { Card, SectionHeader } from '@/components/ios';
-import {
-  LargeNavigationTitle,
-  SyncBadge,
-} from '@/components/native';
+import { SyncBadge } from '@/components/native';
 import { useStorage } from '@/contexts/StorageContext';
 import { SettingsFooter, SettingsRow } from '@/features/preferences/SettingsRow';
 import { semanticColors, spacing } from '@/theme';
@@ -75,8 +72,6 @@ export default function PreferencesScreen() {
       contentInsetAdjustmentBehavior="automatic"
       automaticallyAdjustsScrollIndicatorInsets
     >
-      <LargeNavigationTitle>Settings</LargeNavigationTitle>
-
       <View>
         <SectionHeader>YNAB</SectionHeader>
         <Card>

--- a/apps/mobile/app/(tabs)/recommendations.tsx
+++ b/apps/mobile/app/(tabs)/recommendations.tsx
@@ -9,7 +9,7 @@
 import React, { useMemo } from 'react';
 import { ScrollView, View, StyleSheet, type ColorValue } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/native';
 import { RecommendationEngine } from '@ynab-counter/app-core/rewards-engine';
 import { selectCurrentCardCalculations } from '@ynab-counter/app-core/rewards-engine/utils/recommendation-helpers';
 import type { CardRecommendation } from '@ynab-counter/app-core/rewards-engine/types';
@@ -30,7 +30,6 @@ function getActionDetails(action: CardRecommendation['action']): { label: string
 }
 
 export default function RecommendationsScreen() {
-  const navigation = useNavigation();
   const { state, status } = useStorage();
   const calculations = state.calculations;
   const [referenceDate, setReferenceDate] = React.useState(() => new Date());
@@ -59,22 +58,7 @@ export default function RecommendationsScreen() {
   useFocusEffect(
     React.useCallback(() => {
       setReferenceDate(new Date());
-      const parent = navigation.getParent();
-      parent?.setOptions({
-        headerLargeTitle: false,
-        headerTitle: 'Tips',
-        title: 'Tips',
-        headerRight: undefined,
-        headerSearchBarOptions: undefined,
-      });
-
-      return () => {
-        parent?.setOptions({
-          headerRight: undefined,
-          headerSearchBarOptions: undefined,
-        });
-      };
-    }, [navigation])
+    }, [])
   );
 
   return (

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -413,7 +413,6 @@ export default function SettingsScreen() {
               </Card>
             ) : null}
 
-            <SectionHeader>YNAB Connection</SectionHeader>
             <Card>
               <ListItem>
                 <View style={styles.fieldGroup}>


### PR DESCRIPTION
## Summary
- compress the Overview card-use recommendations into one three-column row
- remove redundant tab-root titles while retaining pushed-screen navigation context
- remove repeated YNAB connection and transaction labels

## Validation
- `corepack pnpm --filter ./apps/mobile typecheck`
- `corepack pnpm --filter ./apps/mobile test` (92 tests)
- `corepack pnpm exec eslint apps/mobile/app --ext .ts,.tsx`
- `corepack pnpm --filter ./apps/mobile exec expo export --platform ios --output-dir /tmp/ynab-rewards-mobile-final`